### PR TITLE
Bootstrap: More work 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,12 @@ QEMU_FLAGS=-s -m 1024 -no-reboot -no-shutdown
 # Run Qemu with the disk image. The GDB server is started as well but Qemu does
 # not wait to start the execution.
 run: disk.img
-	qemu-system-x86_64 -drive file=$<,format=raw $(QEMU_FLAGS)
+	qemu-system-x86_64 -drive file=$<,format=raw $(QEMU_FLAGS) -enable-kvm -cpu host
 
 # Run Qemu with the disk image. The GDB server is started as well and Qemu WAITs
 # for a continue command from a GDB session before starting execution.
 runs: disk.img
-	qemu-system-x86_64 -drive file=$<,format=raw -S $(QEMU_FLAGS)
+	qemu-system-x86_64 -drive file=$<,format=raw -S $(QEMU_FLAGS) -enable-kvm -cpu host
 
 # Clean recursively.
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -23,17 +23,20 @@ disk.img: $(BOOTSTRAP_IMG_PATH) $(APP_PATH)
 	./create_img.py $@ $^
 
 # Set of flags used by Qemu.
-QEMU_FLAGS=-s -m 1024 -no-reboot -no-shutdown
+# Note: The +invtsc indicates to Qemu to add the constant TSC freq extension. It
+# turns out that even if the host support this extension, Qemu does not show it
+# to the VM hence why we need to add it here.
+QEMU_FLAGS=-s -m 1024 -no-reboot -no-shutdown -enable-kvm -cpu host,+invtsc
 
 # Run Qemu with the disk image. The GDB server is started as well but Qemu does
 # not wait to start the execution.
 run: disk.img
-	qemu-system-x86_64 -drive file=$<,format=raw $(QEMU_FLAGS) -enable-kvm -cpu host
+	qemu-system-x86_64 -drive file=$<,format=raw $(QEMU_FLAGS)
 
 # Run Qemu with the disk image. The GDB server is started as well and Qemu WAITs
 # for a continue command from a GDB session before starting execution.
 runs: disk.img
-	qemu-system-x86_64 -drive file=$<,format=raw -S $(QEMU_FLAGS) -enable-kvm -cpu host
+	qemu-system-x86_64 -drive file=$<,format=raw -S $(QEMU_FLAGS)
 
 # Clean recursively.
 .PHONY: clean

--- a/bootstrap/acpi.S
+++ b/bootstrap/acpi.S
@@ -1,0 +1,590 @@
+// This file contains all the routines related to ACPI table parsing. One simply
+// needs to call the init_acpi routine to parse all ACPI tables and initialize
+// state that depend on ACPI tables (such as LAPIC and IOAPIC addresses, NCPUS,
+// IRQ redirections, ...).
+
+#include <asm_macros.h>
+#include <consts.h>
+.intel_syntax   noprefix
+
+.section .data
+// Signature of the Root System Descriptor Pointer (RSDP). This is what we need
+// to look for to find the location of the table.
+rsdp_signature:
+.ascii "RSD PTR "
+
+// Jump table for the _acpi_parse_sdt routine. Each entry of this table is a
+// pair <signature>:<function> where <signature> is a 4 byte string and
+// <function> is a pointer (8 bytes) to the function handling SDTs of the given
+// signature. The table ends with a 0:0 entry.
+acpi_sdt_parsers_table:
+REGISTER_SDT_PARSER("APIC", _acpi_sdt_parser_apic)
+// 0:0 entru indicating the end of the table.
+.skip   12, 0
+
+// The physical address of the LAPIC. This is for any cpu in the system.
+.global LAPIC_ADDR
+LAPIC_ADDR:
+.quad   0x0
+
+// The physical address of the IOAPIC. This _should_ (AFAIK) be valid for any
+// cpu. AFAIK there is only one IOAPIC.
+.global IOAPIC_ADDR
+IOAPIC_ADDR:
+.quad   0x0
+
+// The total number of cpus on the processor.
+.global NCPUS
+NCPUS:
+.byte   0x0
+
+// Array containing the redirected legacy IRQs. This array is indexed by the
+// legacy IRQ vector (0 through 15 included) and maps to the system interrupt.
+// By default the mapping is idempotent, the ACPI tables (more precisely the
+// MADT) will tell us what the actual mapping is.
+.global IRQ_REDIR
+IRQ_REDIR:
+.byte 0x0,0x1,0x2,0x3,0x4,0x5,0x6,0x7,0x8,0x9,0xA,0xB,0xC,0xD,0xE,0xF
+
+// Jump table used by _acpi_sdt_parser_apic to parse the entries of the MADT.
+// This table is indexed by the entry type (which is between 0 and 5 included).
+acpi_sdt_parser_apic_jump_table:
+.quad ._acpi_sdt_parser_apic_target_0
+.quad ._acpi_sdt_parser_apic_target_1
+.quad ._acpi_sdt_parser_apic_target_2
+.quad ._acpi_sdt_parser_apic_target_3
+.quad ._acpi_sdt_parser_apic_target_4
+.quad ._acpi_sdt_parser_apic_target_5
+
+// =============================================================================
+// Try to find the RSDP in a memory region.
+// @param (RDI): Start address of the memory region to scan.
+// @param (RSI): End address of the memory region to scan.
+// @return (RAX): If found, the linear address of the RSDP, otherwise 0x0.
+// =============================================================================
+ASM_FUNC_DEF64(_acpi_find_rsdp_helper):
+    push    rbp
+    mov     rbp, rsp
+
+    // The RSDP is on a 16-bytes aligned address. Hence we might need to fix up
+    // the start or end addresses.
+    and     rdi, ~(16 - 1)
+    and     rsi, ~(16 - 1)
+
+    // RCX = Number of addresses to test, that is the number of 16-bytes aligned
+    // addresses between start and end.
+    mov     rcx, rsi
+    sub     rcx, rdi
+    jns     0f
+    PANIC64("_acpi_find_rsdp_helper: Start address > End address")
+0:
+    shr     rcx, 4
+
+    // To find the RSDP we need to find its signature, a 8 char string.
+    // RAX = Signature.
+    mov     rax, [rsdp_signature]
+._acpi_find_rsdp_helper_loop:
+    scasq
+    je      ._acpi_find_rsdp_helper_found
+    // Since the RSDP is on a 16-byte aligned address, RDI needs to be increased
+    // by 16. It was already inc by 8 by the SCASQ instruction.
+    add     rdi, 8
+    loop     ._acpi_find_rsdp_helper_loop
+
+    // Could not find the RSDP here.
+    xor     rax, rax
+    jmp     ._acpi_find_rsdp_helper_end
+._acpi_find_rsdp_helper_found:
+    // RSDP found at address RDI - 8. The -8 comes from the fact that scasq
+    // increased RDI by 8 on the last iteration.
+    mov     rax, rdi
+    sub     rax, 8
+._acpi_find_rsdp_helper_end:
+    leave
+    ret
+
+// =============================================================================
+// Validate the checksum of an ACPI table. This routine works with the RSDP,
+// RSDT and any SDTs.
+// @param (RDI): Pointer to the table to validate the checksum for.
+// @param (RSI): Length of the table in bytes.
+// @return (RAX): 1 if the checksum is valid, else 0.
+// =============================================================================
+ASM_FUNC_DEF64(_acpi_validate_checksum):
+    push    rbp
+    mov     rbp, rsp
+
+    // Checksums of ACPI tables is done by adding up every bytes of the table
+    // and making sure that the result has its lower byte to 0.
+    // RAX = Sum.
+    xor     rax, rax
+    mov     rcx, rsi
+._acpi_validate_checksum_loop:
+    movzx   rdx, BYTE PTR [rdi + rcx - 1]
+    add     rax, rdx
+    loop    ._acpi_validate_checksum_loop
+
+    // Check lower byte of the sum.
+    test    al, al
+    jz      ._acpi_validate_checksum_ok
+
+    // Checksum is not valid.
+    xor     rax, rax
+    jmp     ._acpi_validate_checksum_end
+._acpi_validate_checksum_ok:
+    mov     rax, 1
+._acpi_validate_checksum_end:
+    leave
+    ret
+
+// =============================================================================
+// Check that the RSDP is supported, that is its revision is ACPI v1 and its
+// checksum is valid.
+// @param (RDI): Pointer to the RSDP.
+// @return (RAX): 1 if the RSDP is valid, 0 otherwise.
+// =============================================================================
+ASM_FUNC_DEF64(_acpi_check_rsdp):
+    push    rbp
+    mov     rbp, rsp
+
+    // First check that the revision of the RSDP is 0, that is ACPI v1. For now
+    // we only support ACPI v1, which is what qemu implements. Support to ACPI
+    // v2 can easily be added later (and will most likely be required for read
+    // hardware).
+    cmp     BYTE PTR [rdi + ACPI_RSDP_REVISION_OFF], 0x0
+    je      0f
+    INFO64("_acpi_check_rsdp: Unsupported ACPI version!\n")
+    xor     rax, rax
+    leave
+    ret
+0:
+    mov     rsi, ACPI_RSDP_SIZE
+    // RAX == Checksum is valid.
+    call    _acpi_validate_checksum
+    leave
+    ret
+
+// =============================================================================
+// Find the RSDP.
+// @return (RAX): The linear address of the RSDP. If no RSDP is found this
+// routine will panic. The address returned is guaranteed to be ID mapped in
+// virtual address space (since the lower 1MiB is ID mapped).
+// =============================================================================
+ASM_FUNC_DEF64(_acpi_find_rsdp):
+    push    rbp
+    mov     rbp, rsp
+
+    // RSDP is either located:
+    //  - In the first 1KiB of the Extended BIOS Data Area (EBDA).
+    //  - Between 0x000E0000 and 0x000FFFFF.
+
+    // First location.
+    mov     rdi, 0x80000
+    // The -16 because RSDP is always on a 16-byte aligned address.
+    mov     rsi, 0x80000 + 1024 - 16
+    call    _acpi_find_rsdp_helper
+    test    rax, rax
+    jnz     ._acpi_find_rsdp_found
+
+    // Second location.
+    mov     rdi, 0x000E0000
+    mov     rsi, 0x000FFFFF - 16
+    call    _acpi_find_rsdp_helper
+    test    rax, rax
+    jnz     ._acpi_find_rsdp_found
+
+    // Could not find the RSDP.
+    PANIC64("_acpi_find_rsdp: No RSDP found in standard locations.")
+
+._acpi_find_rsdp_found:
+    // RAX = Address of RSDP.
+    push    rax
+    INFO64("RSDP found @ %q\n")
+    pop     rax
+    // Check that the RSDP is valid (correct revision and checksum is valid).
+    // This will panic if it isn't.
+    push    rax
+    mov     rdi, rax
+    call    _acpi_check_rsdp
+
+    test    rax, rax
+    jnz     0f
+    PANIC64("_acpi_find_rsdp: RSDP is not valid or supported")
+
+0:
+    pop     rax
+
+    leave
+    ret
+
+// =============================================================================
+// Check that an SDT is valid, that is its checksum is valid.
+// @param (RDI): pointer to SDT. This must point to the header of the SDT.
+// @return (RAX): 1 if the checksum is valid, 0 otherwise.
+// =============================================================================
+ASM_FUNC_DEF64(_acpi_check_sdt):
+    push    rbp
+    mov     rbp, rsp
+
+    // RSI = Length of SDT.
+    mov     esi, DWORD PTR [rdi + ACPI_SDT_HDR_LENGTH_OFF]
+    // RAX = checksum is valid.
+    call    _acpi_validate_checksum
+    leave
+    ret
+
+// =============================================================================
+// Map a SDT to virtual memory and check its checksum. If the checksum is
+// invalid this routine will PANIC! This routine works with both the RSDT or a
+// regular SDT.
+// @param (RDI): PHYSICAL address of the SDT.
+// @return (RAX): The virtual address where the SDT has been mapped to.
+// Note: The caller of this routine should unmap the SDT once it is not using it
+// anymore.
+// =============================================================================
+ASM_FUNC_DEF64(_acpi_map_and_check_sdt):
+    push    rbp
+    mov     rbp, rsp
+
+    // FIXME: For now we are using an ID map.
+    // Step 1: Map the header of the table so that we can read its length.
+    push    rdi
+    mov     rsi, rdi
+    mov     rdx, ACPI_SDT_HDR_SIZE
+    mov     rcx, MAP_READ_ONLY
+    call    map
+    pop     rdi
+
+    // RDX = Total length of table (including the header).
+    mov     edx, DWORD PTR [rdi + ACPI_SDT_HDR_LENGTH_OFF] 
+
+    // Step 2: Map the entire table.
+    push    rdi
+    mov     rsi, rdi
+    mov     rcx, MAP_READ_ONLY
+    call    map
+    pop     rdi
+
+    // Step 3: Validate the checksum.
+    push    rdi
+    call    _acpi_check_sdt
+    test    rax, rax
+    jnz     0f
+    PANIC64("init_acpi: SDT checksum is invalid")
+0:
+    // RAX = Virtual address of the SDT (= RDI).
+    pop     rax
+    leave
+    ret
+
+// =============================================================================
+// Unmap a SDT that has been mapped to virtual address space.
+// @param (RDI): Virtual address of the SDT to unmap.
+// =============================================================================
+ASM_FUNC_DEF64(_acpi_unmap_sdt):
+    // TODO: Once we have a routine to unmap virtual addresses, we should call
+    // it here.
+    ret
+
+
+// =============================================================================
+// Parser for SDT with signature = "APIC". This routine must be called by
+// _acpi_parse_sdt only.
+// @param (RDI): Pointer on the SDT to parse.
+// =============================================================================
+ASM_FUNC_DEF64(_acpi_sdt_parser_apic):
+    push    rbp
+    mov     rbp, rsp
+    push    rbx
+    push    r12
+
+    // We don't bother checking the signature again. Trust the _acpi_parse_sdt
+    // routine for that. If you are calling this function yourself you are
+    // asking for troubles anyway.
+    
+    // The MADT gives us the LAPIC address. Save this address for later when we
+    // initialize the LAPIC.
+    mov     eax, [rdi + ACPI_MADT_LAPIC_ADDR_OFF]
+    mov     [LAPIC_ADDR], rax
+
+    // Now parse each entry of the MADT. Entries have variable length, but all
+    // start with a common header:
+    //  (BYTE) Entry type.
+    //  (BYTE) Entry length (including the entry header).
+    // RBX = Entry iterator.
+    lea     rbx, [rdi + ACPI_MADT_ENTRIES_OFF]
+    // R12 = Stop addr.
+    mov     r12d, [rdi + ACPI_SDT_HDR_LENGTH_OFF]
+    add     r12, rdi
+    jmp     ._acpi_sdt_parser_apic_cond
+._acpi_sdt_parser_apic_loop:
+    // AL = Entry type.
+    movzx   rax, BYTE PTR [rbx]
+    cmp     rax, 5
+    jbe     0f
+    PANIC64("_acpi_sdt_parser_apic: Invalid entry type")
+0:
+    // Use the jump table to jump to the correct label.
+    jmp     [acpi_sdt_parser_apic_jump_table + rax * 8]
+
+    // Each label below handles a given entry type. The following invariants
+    // hold true when the execution flow reaches any label:
+    //  - RBX points to the entry (to the header of the entry).
+
+    // Type 0 => Processor Local APIC. There is one such entry for each core on
+    // the cpu. This entry has the following content.
+    //  Offset  | Len   | Desc
+    //  --------+-------+-------------------------------------------------------
+    //  0x2     | 0x1   | ACPI Processor ID
+    //  0x3     | 0x1   | APIC ID
+    //  0x4     | 0x4   | Flags (bit 0 = cpu enabled, bit 1 = online capable)
+._acpi_sdt_parser_apic_target_0:
+    DEBUG64("Entry type = 0 (LAPIC)\n")
+    // If this cpu is online capable OR enabled, increment the NCPUS.
+    mov     eax, [rbx + 0x4]
+    test    eax, eax
+    setnz   al
+    add     BYTE PTR [NCPUS], al
+    jmp     ._acpi_sdt_parser_apic_next
+
+    // Type 1 => I/O APIC. There is one entry for each I/O APIC.
+    //  Offset  | Len   | Desc
+    //  --------+-------+-------------------------------------------------------
+    //  0x2     | 0x1   | I/O APIC's ID
+    //  0x3     | 0x1   | Reserved (0)
+    //  0x4     | 0x4   | I/O APIC Address
+    //  0x8     | 0x4   | Global System Interrupt Base 
+    // The global system interrupt base is the first interrupt number that this
+    // I/O APIC handles
+._acpi_sdt_parser_apic_target_1:
+    DEBUG64("Entry type = 1 (IOAPIC)\n")
+    // Save the address of the IOAPIC.
+    mov     eax, [rbx + 0x4]
+    mov     [IOAPIC_ADDR], rax
+
+    // Make sure that the base is 0. This is because we only support one IOAPIC
+    // max.
+    cmp     DWORD PTR [rbx + 0x8], 0x0
+    je      ._acpi_sdt_parser_apic_next
+    PANIC64("_acpi_sdt_parser_apic: IOAPIC does not have base = 0")
+
+    // Type 2 => Interrupt Source Override. This explains how IRQ sources are
+    // mapped to global system interrupts.
+    //  Offset  | Len   | Desc
+    //  --------+-------+-------------------------------------------------------
+    //  0x2     | 0x1   | Bus Source
+    //  0x3     | 0x1   | IRQ Source e.g the legacy interrupt
+    //  0x4     | 0x4   | Global System Interrupt e.g where IRQ is redirected
+    //  0x8     | 0x2   | Flags (unused here)
+._acpi_sdt_parser_apic_target_2:
+    DEBUG64("Entry type = 2 (Interrupt Source Override)\n")
+    // RAX = Legacy IRQ vector.
+    movzx   eax, BYTE PTR [rbx + 0x3]
+    // CL = New vector.
+    mov     cl, [rbx + 0x4]
+    // Save the redirection.
+    mov     BYTE PTR [IRQ_REDIR + rax], cl
+    
+    movzx   rcx, cl
+    push    rcx
+    push    rax
+    DEBUG64("IRQ %b redirected to vector %b\n")
+    add     esp, 0x10
+
+    jmp     ._acpi_sdt_parser_apic_next
+
+    // Type 3 => Invalid type.
+._acpi_sdt_parser_apic_target_3:
+    PANIC64("_acpi_sdt_parser_apic: Invalid entry type 3")
+
+    // Type 4 => Non-maskable interrupts. Unused in this project.
+._acpi_sdt_parser_apic_target_4:
+    DEBUG64("Entry type = 4 (Non-maskable interrupts)\n")
+    jmp     ._acpi_sdt_parser_apic_next
+
+    // Type 5 => Local APIC Address Override. Provides 64 bit systems with an
+    // override of the physical address of the Local APIC. There can only be one
+    // of these defined in the MADT. If this structure is defined, the 64-bit
+    // Local APIC address stored within it should be used instead of the 32-bit
+    // Local APIC address stored in the MADT header.
+    //  Offset  | Len   | Desc
+    //  --------+-------+-------------------------------------------------------
+    //  0x2     | 0x2   | Reserved
+    //  0x4     | 0x8   | 64-bit physical address of Local APIC
+._acpi_sdt_parser_apic_target_5:
+    DEBUG64("Entry type = 5 (Local APIC Address Override)\n")
+    // Since we already parsed the address of the LAPIC from the MADT, if we
+    // find this type of entry then we simply need to overwrite the saved
+    // LAPIC_ADDR.
+    mov     rax, [rbx + 0x4]
+    mov     [LAPIC_ADDR], rax
+    jmp     ._acpi_sdt_parser_apic_next
+
+._acpi_sdt_parser_apic_next:
+    // Advance to next entry by adding the entry's length to the iterator.
+    // RAX = Entry's length.
+    movzx   rax, BYTE PTR [rbx + 1]
+    add     rbx, rax
+._acpi_sdt_parser_apic_cond:
+    // Loop until we reach the end of the MADT (R12).
+    cmp     rbx, r12
+    jb      ._acpi_sdt_parser_apic_loop
+
+    pop     r12
+    pop     rbx
+    leave
+    ret
+
+// =============================================================================
+// Parse an SDT. This routine will look for a parser for the given signature in
+// the acpi_sdt_parsers_table and, if any, calls it with the SDT as argument.
+// @param (RDI): Pointer on the SDT to parse.
+// =============================================================================
+ASM_FUNC_DEF64(_acpi_parse_sdt):
+    push    rbp
+    mov     rbp, rsp
+
+    push    rbx
+    
+    // Map the SDT to virtual memory and validate its checksum.
+    // RBX = Virtual address of SDT.
+    call    _acpi_map_and_check_sdt
+    mov     rbx, rax
+
+    push    rax
+    DEBUG64("_acpi_parse_sdt: SDT @ %q has signature: ")
+    pop     rax
+    
+    // Some shenanigans to print the signature. FIXME: It would _really_ help to
+    // have the %s substitution for the logging functions.
+    push    rbx
+    mov     ecx, DWORD PTR [rbx]
+    mov     rdx, '\n' << 32
+    or      rcx, rdx
+    push    rcx
+    mov     rdi, rsp
+    call    printf64 
+    add     esp, 8
+    pop     rbx
+
+    // Find a parser (if any) for this SDT in the parser table.
+    // RCX = Iterator on the table.
+    lea     rcx, [acpi_sdt_parsers_table]
+    // EDX = Signature of current SDT.
+    mov     edx, DWORD PTR [rbx + ACPI_SDT_HDR_SIGNATURE_OFF]
+    jmp     ._acpi_parse_sdt_find_loop_cond
+._acpi_parse_sdt_find_loop:
+    // Compare the signature with the entry.
+    cmp     edx, DWORD PTR [rcx]
+    jne     ._acpi_parse_sdt_find_loop_next
+    
+    // This is the same signature, call the parser.
+    mov     rdi, rbx
+    mov     rax, [rcx + 4]
+    call    rax
+    // Break out of the loop.
+    jmp     ._acpi_parse_sdt_end
+
+._acpi_parse_sdt_find_loop_next:
+    // Advance iterator. Each entry in the table is 12 bytes.
+    add     rcx, 12
+._acpi_parse_sdt_find_loop_cond:
+    cmp     DWORD PTR [rcx], 0x0
+    jne     ._acpi_parse_sdt_find_loop
+
+    // If we reach this point then no parser was found for this signature, then
+    // we simply ignore this table. 
+    DEBUG64("No parser for current SDT\n")
+._acpi_parse_sdt_end:
+
+    // Unmap the table from virtual memory.
+    mov     rdi, rbx
+    call    _acpi_unmap_sdt
+
+    pop     rbx
+    leave
+    ret
+
+// =============================================================================
+// Parse the RSDT and all SDTs that it refers to.
+// @param (RDI): Pointer to RSDT.
+// =============================================================================
+ASM_FUNC_DEF64(_acpi_parse_rsdt):
+    push    rbp
+    mov     rbp, rsp
+    push    rbx
+    // The RSDT (as of ACPI v1) is composed of the SDT header followed by an
+    // array of 32-bit pointer (physical addresses) of the other SDTs. This
+    // array contains N = (rsdt.length - sizeof(sdt header)) / 4 entries.
+
+    // RCX = N = number of entries in array.
+    mov     ecx, DWORD PTR [rdi + ACPI_SDT_HDR_LENGTH_OFF]
+    sub     rcx, ACPI_SDT_HDR_SIZE
+    shr     rcx, 2
+
+    push    rdi
+    push    rcx
+    DEBUG64("_acpi_parse_rsdt: RSDT contains %d entries\n")
+    pop     rcx
+    pop     rdi
+
+    // Iterate over the array of pointer to parse all SDTs.
+    // RBX = Iterator on array.
+    mov     rbx, rdi
+    add     rbx, ACPI_SDT_HDR_SIZE
+._acpi_parse_rsdt_loop:
+    // Save iteration count.
+    push    rcx
+
+    // Parse SDT.
+    mov     edi, [rbx]
+    call    _acpi_parse_sdt 
+
+    // Advance iterator and go to next iteration.
+    add     rbx, 4
+    pop     rcx
+    loop    ._acpi_parse_rsdt_loop
+
+    pop     rbx
+    leave
+    ret
+
+// =============================================================================
+// Parse all ACPI tables and initialize any state depending on them (LAPIC and
+// IOAPIC addresses, NCPUS, IRQ redirection, ...), basically any global symbol
+// from the .data section of this file.
+// =============================================================================
+ASM_FUNC_DEF64(init_acpi):
+    push    rbp
+    mov     rbp, rsp
+
+    push    rbx
+
+    // Step 1: Find the Root System Descriptor Pointer (RSDP).
+    // RAX = Address of RSDP.
+    call    _acpi_find_rsdp
+
+    // RBX = Address of RSDT.
+    mov     ebx, DWORD PTR [rax + ACPI_RSDP_RSDT_ADDR_OFF]
+
+    // Map the RSDT to virtual memory.
+    mov     rdi, rbx
+    call    _acpi_map_and_check_sdt
+
+    push    rbx
+    DEBUG64("RSDT @ %q\n")
+    add     esp, 8
+
+    // Parse the RSDT and all SDTs pointed by it.
+    mov     rdi, rbx
+    call    _acpi_parse_rsdt
+
+    // Unmap the RSDT.
+    mov     rdi, rbx
+    call    _acpi_unmap_sdt
+
+    INFO64("ACPI tables successfully parsed\n")
+
+    pop     rbx
+    leave
+    ret

--- a/bootstrap/asm_macros.h
+++ b/bootstrap/asm_macros.h
@@ -130,3 +130,11 @@
     _PRINTF32("[WARN ] :", fmt)
 #define WARN64(fmt)   ;\
     _PRINTF64("[WARN ] :", fmt)
+
+// Register a function as a parser for a given SDT signature. This is only used
+// in acpi.S.
+// @param signature: A 4-byte string containing the signature.
+// @param func: A pointer to the function parsing such SDTs.
+#define REGISTER_SDT_PARSER(signature, func)    ;\
+    .ascii signature                            ;\
+    .quad func

--- a/bootstrap/bootstrap.S
+++ b/bootstrap/bootstrap.S
@@ -206,8 +206,14 @@ ASM_FUNC_DEF32(bootstrap_main):
 
     // Now that we parse the ACPI tables, we know the addresses of the LAPIC and
     // IOAPIC. Initialize them.
-    call    init_lapic
+    // We need to initialize the IOAPIC before the LAPIC since the LAPIC timer
+    // calibration will need to re-route PIT IRQ 0.
     call    init_ioapic
+    call    init_lapic
+
+    // Compute or calibrate the TSC's frequency. This must be done after
+    // initializing the I/O APIC and LAPIC as it might use the PIT to calibrate.
+    call    init_tsc
 
     // We are now in long mode, hence paging is enabled (mandatory for long
     // mode), therefore we cannot access the physical memory containing the

--- a/bootstrap/bootstrap.S
+++ b/bootstrap/bootstrap.S
@@ -217,6 +217,11 @@ ASM_FUNC_DEF32(bootstrap_main):
     // Run 64-bits tests once everything is initialized.
     call    run_tests64
 
+    // Initialize syscalls. This must be done after running the tests because
+    // the interrupt tests will try to register callback for all vectors
+    // including the INTERRUPT_SYSCALL_VEC.
+    call    init_syscall
+
     // We are now in long mode, hence paging is enabled (mandatory for long
     // mode), therefore we cannot access the physical memory containing the
     // loaded file. Map those frames now.

--- a/bootstrap/bootstrap.S
+++ b/bootstrap/bootstrap.S
@@ -396,7 +396,11 @@ ASM_FUNC_DEF32(copy_elf_file_to_ram):
     // Allocate the physical frames to load the file into.
     push    ecx
     // EAX = Start address where to copy the file.
-    call    allocate_contiguous_frames32
+    call    allocate_n_frames32
+    cmp     eax, NO_FRAME
+    jne     0f
+    PANIC32("copy_elf_file_to_ram: Could not allocate enough contiguous frames")
+0:
     add     esp, 4
     // Save file start addr.
     mov     [file_start_addr], eax

--- a/bootstrap/bootstrap.S
+++ b/bootstrap/bootstrap.S
@@ -197,6 +197,10 @@ ASM_FUNC_DEF32(bootstrap_main):
 
 .code64
 .long_mode_target:
+    // Initialize interrupts ASAP. This will be useful to detect any faults in
+    // subsequent initialization routines.
+    call    init_interrupt
+
     // Parse ACPI tables. This must be done in long mode.
     call    init_acpi
 

--- a/bootstrap/bootstrap.S
+++ b/bootstrap/bootstrap.S
@@ -200,6 +200,7 @@ ASM_FUNC_DEF32(bootstrap_main):
     // Initialize interrupts ASAP. This will be useful to detect any faults in
     // subsequent initialization routines.
     call    init_interrupt
+    call    init_ioapic
 
     // Parse ACPI tables. This must be done in long mode.
     call    init_acpi

--- a/bootstrap/bootstrap.S
+++ b/bootstrap/bootstrap.S
@@ -233,8 +233,18 @@ ASM_FUNC_DEF32(bootstrap_main):
     INFO64("Entry point is %q\n")
     pop     rax
 
+    // Map the framebuffer to virtual memory so that it is accessible from the
+    // application.
+    push    rax
+    call    map_framebuffer
+    pop     rax
+
     // Call the entry point of the process.
-    mov     rdi, [putc_vga_buffer_cursor]
+    // Pass a struct containing information about the video-mode/framebuffer.
+    // This struct is a sub-struct of the mode info block starting at offset
+    // 0x10.
+    mov     rdi, [mode_info_block]
+    add     rdi, 0x10
     call    rax
 
     // In case we ever return from the process make sure that we don't

--- a/bootstrap/bootstrap.S
+++ b/bootstrap/bootstrap.S
@@ -429,7 +429,7 @@ ASM_FUNC_DEF32(copy_elf_file_to_ram):
     call    printf32
     add     esp, 4
     push    '\n'
-    call    putc_vga_buffer32
+    call    _putc32
     add     esp, 4
     push    DWORD PTR [ebx + METADATA_SIZE_OFF]
     INFO32("Size     : %d bytes\n")

--- a/bootstrap/bootstrap.S
+++ b/bootstrap/bootstrap.S
@@ -565,6 +565,7 @@ file_num_frames:
 // data segment and under 0xFFFF so that they will always be accessible from
 // real-mode code.
 // @param (DWORD) size: The number of bytes to allocated.
+// @return (EAX): Address of allocated memory.
 // ============================================================================= 
 ASM_FUNC_DEF32(allocate_low_mem):
     push    ebp
@@ -581,6 +582,34 @@ ASM_FUNC_DEF32(allocate_low_mem):
 
     // The address will not fit in a 16-bit registers.
     PANIC32("No space left\n")
+0:
+
+    // Allocation OK. Move the alloc_addr.
+    mov     [alloc_addr], ecx
+    // EAX is already pointing to the beginning of the allocated memory.
+    leave
+    ret
+
+// ============================================================================= 
+// 64-bit version of the low-memory allocator.
+// @param (RDI): Number of bytes to allocate.
+// @return (RAX): Address of the allocated memory.
+// ============================================================================= 
+ASM_FUNC_DEF64(allocate_low_mem64):
+    push    rbp
+    mov     rbp, rsp
+
+    // EAX = Address of next allocation (this allocation).
+    mov     eax, [alloc_addr]
+
+    // ECX = New address of alloc_addr.
+    mov     ecx, eax
+    add     ecx, edi
+    cmp     eax, 0xFFFF
+    jb      0f
+
+    // The address will not fit in a 16-bit registers.
+    PANIC64("No space left\n")
 0:
 
     // Allocation OK. Move the alloc_addr.

--- a/bootstrap/bootstrap.S
+++ b/bootstrap/bootstrap.S
@@ -160,6 +160,7 @@ ASM_FUNC_DEF32(call_real_mode):
 // Does not return.
 // ============================================================================= 
 ASM_FUNC_DEF32(bootstrap_main):
+    call    init_serial
     call    init_cache
     call    clear_vga_buffer32
 

--- a/bootstrap/bootstrap.S
+++ b/bootstrap/bootstrap.S
@@ -200,10 +200,14 @@ ASM_FUNC_DEF32(bootstrap_main):
     // Initialize interrupts ASAP. This will be useful to detect any faults in
     // subsequent initialization routines.
     call    init_interrupt
-    call    init_ioapic
 
     // Parse ACPI tables. This must be done in long mode.
     call    init_acpi
+
+    // Now that we parse the ACPI tables, we know the addresses of the LAPIC and
+    // IOAPIC. Initialize them.
+    call    init_lapic
+    call    init_ioapic
 
     // We are now in long mode, hence paging is enabled (mandatory for long
     // mode), therefore we cannot access the physical memory containing the

--- a/bootstrap/bootstrap.S
+++ b/bootstrap/bootstrap.S
@@ -170,8 +170,7 @@ ASM_FUNC_DEF32(bootstrap_main):
 
     INFO32("Bootstrap main started\n")
 
-    INFO32("Running tests\n")
-    call    run_tests
+    call    run_tests32
 
     call    init_mem_map
     call    init_frame_allocator
@@ -214,6 +213,9 @@ ASM_FUNC_DEF32(bootstrap_main):
     // Compute or calibrate the TSC's frequency. This must be done after
     // initializing the I/O APIC and LAPIC as it might use the PIT to calibrate.
     call    init_tsc
+
+    // Run 64-bits tests once everything is initialized.
+    call    run_tests64
 
     // We are now in long mode, hence paging is enabled (mandatory for long
     // mode), therefore we cannot access the physical memory containing the

--- a/bootstrap/bootstrap.S
+++ b/bootstrap/bootstrap.S
@@ -180,6 +180,10 @@ ASM_FUNC_DEF32(bootstrap_main):
     // Copy the ELF file into RAM.
     call    copy_elf_file_to_ram
 
+    // Before leaving 32-bit mode for long mode, initialize the video mode. This
+    // is the last chance we have to do so.
+    call    init_video
+
     // Initialize long mode and jump to it. Warn: This is the point of no
     // return, as for now there is no way to come back from long mode to 32-bit
     // mode. Hence no possible way to interact with the BIOS after that!

--- a/bootstrap/bootstrap.S
+++ b/bootstrap/bootstrap.S
@@ -174,6 +174,7 @@ ASM_FUNC_DEF32(bootstrap_main):
 
     call    init_mem_map
     call    init_frame_allocator
+    call    init_fpu
 
     // Copy the ELF file into RAM.
     call    copy_elf_file_to_ram
@@ -255,6 +256,63 @@ ASM_FUNC_DEF32(init_cache):
 
     leave
     ret
+
+// ============================================================================= 
+// Initialize the FPU for AVX-2. This routine will make sure that the processor
+// supports this extension and will panic otherwise.
+// ============================================================================= 
+ASM_FUNC_DEF32(init_fpu):
+    push    ebp
+    mov     ebp, esp
+
+    // First check that the cpu supports XSAVE and XRSTOR.
+    mov     eax, 1
+    cpuid
+    test    ecx, (1 << 26)
+    jz      .init_fpu_no_xsave_xrstor
+
+    // XSAVE and XRSTOR supported, Enable XGETBV by setting the CR4.OSXSAVE[bit
+    // 18].
+    mov     eax, cr4
+    or      eax, (1 << 18)
+    mov     cr4, eax
+
+    // Check that the CPU supports AVX-2 (which is what we will be using
+    // in the application):
+    //  - CPUID.1:ECX.OSXSAVE[bit 27] = 1. This was done by setting the OSXSAVE
+    //  bit in CR4.
+    //  - CPUID.1:ECX.AVX[bit 28]. Indicate the support.
+    xor     ecx, ecx
+    mov     eax, 1
+    cpuid
+    and     ecx, ((1 << 27) | (1 << 28))
+    cmp     ecx, ((1 << 27) | (1 << 28))
+    jne     .init_fpu_no_avx
+
+    // AVX-2 is supported. Now set bits 1 and 2 in the XCR0.
+    xor     ecx, ecx
+    xgetbv
+    or      eax, ((1 << 1) | (1 << 2))
+    xsetbv
+
+    // Set the MP and NE bits in CR0.
+    mov     eax, cr0
+    or      eax, ((1 << 1) | (1 << 5))
+    mov     cr0, eax
+
+    // Set bits for SSE in CR4.
+    mov     eax, cr4
+    or      eax, ((1 << 9) | (1 << 10))
+    mov     cr4, eax
+
+    // Init FPU.
+    finit
+
+    leave
+    ret
+.init_fpu_no_xsave_xrstor:
+.init_fpu_no_avx:
+    PANIC32("Processor does not support AVX-2 extension.\n")
 
 // ============================================================================= 
 // Read a sector from the boot disk.

--- a/bootstrap/bootstrap.S
+++ b/bootstrap/bootstrap.S
@@ -197,6 +197,9 @@ ASM_FUNC_DEF32(bootstrap_main):
 
 .code64
 .long_mode_target:
+    // Parse ACPI tables. This must be done in long mode.
+    call    init_acpi
+
     // We are now in long mode, hence paging is enabled (mandatory for long
     // mode), therefore we cannot access the physical memory containing the
     // loaded file. Map those frames now.

--- a/bootstrap/consts.h
+++ b/bootstrap/consts.h
@@ -261,4 +261,6 @@
 #define SYSNR_GET_TSC_FREQ  0x2
 // Syscall to print a NUL-terminated string in the serial console.
 #define SYSNR_LOG_SERIAL    0x3
+// Syscall to alloc/dealloc heap memory.
+#define SYSNR_SBRK          0x4
 // ============================================================================= 

--- a/bootstrap/consts.h
+++ b/bootstrap/consts.h
@@ -254,7 +254,9 @@
 //
 // Syscall numbers:
 // Test syscall 0. Reserved for testing purposes.
-#define SYSNR_TEST0 0x0
+#define SYSNR_TEST0         0x0
 // Test syscall 1. Reserved for testing purposes.
-#define SYSNR_TEST1 0x1
+#define SYSNR_TEST1         0x1
+// Syscall to get the TSC's frequency in Hz.
+#define SYSNR_GET_TSC_FREQ  0x2
 // ============================================================================= 

--- a/bootstrap/consts.h
+++ b/bootstrap/consts.h
@@ -123,3 +123,55 @@
 // (NUL-terminated string) The name of the file.
 #define METADATA_NAME_OFF       0x8
 // ============================================================================= 
+
+// ============================================================================= 
+// ACPI offsets and constants.
+// Root System Descriptor Pointer (RSDP) offsets:
+// (QWORD) Signature of the table, must contain "RSD PTR ".
+#define ACPI_RSDP_SIGNATURE_OFF 0x00
+// (BYTE) Checksum of the RSDP.
+#define ACPI_RSDP_CHECKSUM_OFF  0x08
+// (6 BYTES) OEM identifier.
+#define ACPI_RSDP_OEMID_OFF     0x09
+// (BYTE) Revision. 0 -> ACPI v1, 1 -> ACPI v2 to v6.1.
+#define ACPI_RSDP_REVISION_OFF  0x0F
+// (DWORD) Linear Address of the RSDT.
+#define ACPI_RSDP_RSDT_ADDR_OFF 0x10
+// Size of a RSDP for ACPI v1.
+#define ACPI_RSDP_SIZE  0x14
+
+// System Descriptor Table (SDT) header offsets:
+// (4 BYTES) Signature of the SDT.
+#define ACPI_SDT_HDR_SIGNATURE_OFF          0x0
+// (DWORD) Length of the SDT in bytes, including the header.
+#define ACPI_SDT_HDR_LENGTH_OFF             0x4
+// (BYTE) Revision of the SDT.
+#define ACPI_SDT_HDR_REVISION_OFF           0x8
+// (BYTE) Checksum so that the sum of all bytes has its lower byte to 0x0.
+#define ACPI_SDT_HDR_CHECKSUM_OFF           0x9
+// (6 BYTES) OEM ID String.
+#define ACPI_SDT_HDR_OEMID_OFF              0xA
+// (8 BYTES) OEM ID String bis.
+#define ACPI_SDT_HDR_OEMTABLEID_OFF         0x10
+// (DWORD) OEM Revision.
+#define ACPI_SDT_HDR_OEMREVISION_OFF        0x18
+// (DWORD) Creator ID.
+#define ACPI_SDT_HDR_CREATORID_OFF          0x1C
+// (DWORD) Creator Revision.
+#define ACPI_SDT_HDR_CREATORREVISION_OFF    0x20
+// Size of a SDT header.
+#define ACPI_SDT_HDR_SIZE ACPI_SDT_HDR_CREATORREVISION_OFF + 4
+
+// Offsets for SDT with signature == "APIC", those tables are also known as
+// Multiple APIC Description Table (MADT). An MADT starts with an SDT header
+// followed by the fields:
+// (DWORD) Physical address of the LAPIC.
+#define ACPI_MADT_LAPIC_ADDR_OFF    0x24
+#define ACPI_MADT_ENTRIES_OFF       0x2C
+// The MADT then contains an arbitrary number of variable sized entries. Each
+// entry starts with a header:
+// (BYTE) Type of the entry. See acpi.S for more info about the different types.
+#define ACPI_MADT_ENTRY_TYPE_OFF    0x0
+// (BYTE) Length of the entry in byte, including the header.
+#define ACPI_MADT_ENTRY_LENGTH_OFF  0x1
+// ============================================================================= 

--- a/bootstrap/consts.h
+++ b/bootstrap/consts.h
@@ -182,6 +182,10 @@
 // will handle interrupts vectors 0, 1, ..., X - 1.
 #define INTERRUPT_IDT_SIZE  0x30
 
+// Vectors used in this project:
+// Vector used for the redirected PIT IRQs.
+#define INTERRUPT_PIT_VEC   0x20
+
 // Offsets for the interrupt frame constructed by the generic interrupt handler.
 // (QWORD) RDI value at the time of the interrupt.
 #define INT_FRAME_SAVED_RDI_OFF     0x00
@@ -212,4 +216,17 @@
 #define INT_FRAME_RSP_OFF           0x60
 // (QWORD) SS at the time of the interrupt.
 #define INT_FRAME_SS_OFF            0x68
+// ============================================================================= 
+
+// ============================================================================= 
+// Programmable Interval Timer (PIT) constants.
+// This is the base frequency of the crystal oscillator of the PIT.
+#define PIT_BASE_FREQ   1193182
+// Choose a reload value so that PIT_FREQ % RELOAD_VAL == 0 as to avoid rounding
+// errors! 29102 is the biggest divisor of the PIT frequency.
+#define PIT_RELOAD_VAL  29102
+// This is the divided frequency. THIS IS THE DROID YOU ARE LOOKING FOR!!
+// Throughout this project, the PIT is ALWAYS running at this frequency. DO NOT
+// use PIT_BASE_FREQ in computations!
+#define PIT_FREQ        (PIT_BASE_FREQ / PIT_RELOAD_VAL)
 // ============================================================================= 

--- a/bootstrap/consts.h
+++ b/bootstrap/consts.h
@@ -175,3 +175,41 @@
 // (BYTE) Length of the entry in byte, including the header.
 #define ACPI_MADT_ENTRY_LENGTH_OFF  0x1
 // ============================================================================= 
+
+// ============================================================================= 
+// Interrupt related constants.
+// The size of the IDT in number of entries, if this value is X then the IDT
+// will handle interrupts vectors 0, 1, ..., X - 1.
+#define INTERRUPT_IDT_SIZE  0x30
+
+// Offsets for the interrupt frame constructed by the generic interrupt handler.
+// (QWORD) RDI value at the time of the interrupt.
+#define INT_FRAME_SAVED_RDI_OFF     0x00
+// (QWORD) RSI value at the time of the interrupt.
+#define INT_FRAME_SAVED_RSI_OFF     0x08
+// (QWORD) RBP value at the time of the interrupt.
+#define INT_FRAME_SAVED_RBP_OFF     0x10
+// (QWORD) RBX value at the time of the interrupt.
+#define INT_FRAME_SAVED_RBX_OFF     0x18
+// (QWORD) RDX value at the time of the interrupt.
+#define INT_FRAME_SAVED_RDX_OFF     0x20
+// (QWORD) RCX value at the time of the interrupt.
+#define INT_FRAME_SAVED_RCX_OFF     0x28
+// (QWORD) RAX value at the time of the interrupt.
+#define INT_FRAME_SAVED_RAX_OFF     0x30
+// (QWORD) Vector of the interrupt.
+#define INT_FRAME_VECTOR_OFF        0x38
+// (QWORD) Error code of the interrupt. For vector that do not push error code
+// or software interrupts this value is a placeholder.
+#define INT_FRAME_ERROR_CODE_OFF    0x40
+// (QWORD) RIP at the time of the interrupt.
+#define INT_FRAME_RIP_OFF           0x48
+// (QWORD) CS at the time of the interrupt.
+#define INT_FRAME_CS_OFF            0x50
+// (QWORD) RFLAGS at the time of the interrupt.
+#define INT_FRAME_RFLAGS_OFF        0x58
+// (QWORD) RSP at the time of the interrupt.
+#define INT_FRAME_RSP_OFF           0x60
+// (QWORD) SS at the time of the interrupt.
+#define INT_FRAME_SS_OFF            0x68
+// ============================================================================= 

--- a/bootstrap/consts.h
+++ b/bootstrap/consts.h
@@ -56,6 +56,9 @@
 // ============================================================================= 
 // Frame allocator consts.
 #define PAGE_SIZE 4096
+// Indicate failure during the frame allocation. Any value that is not page
+// aligned works.
+#define NO_FRAME  0xFFFFFFFF
 
 // The following are the offsets used for the nodes of the allocator's linked
 // list.

--- a/bootstrap/consts.h
+++ b/bootstrap/consts.h
@@ -184,7 +184,9 @@
 
 // Vectors used in this project:
 // Vector used for the redirected PIT IRQs.
-#define INTERRUPT_PIT_VEC   0x20
+#define INTERRUPT_PIT_VEC       0x20
+// Vector used for syscalls through software interrupts.
+#define INTERRUPT_SYSCALL_VEC   0x21
 
 // Offsets for the interrupt frame constructed by the generic interrupt handler.
 // (QWORD) R15 value at the time of the interrupt.
@@ -245,4 +247,14 @@
 // Throughout this project, the PIT is ALWAYS running at this frequency. DO NOT
 // use PIT_BASE_FREQ in computations!
 #define PIT_FREQ        (PIT_BASE_FREQ / PIT_RELOAD_VAL)
+// ============================================================================= 
+
+// ============================================================================= 
+// Syscall constants.
+//
+// Syscall numbers:
+// Test syscall 0. Reserved for testing purposes.
+#define SYSNR_TEST0 0x0
+// Test syscall 1. Reserved for testing purposes.
+#define SYSNR_TEST1 0x1
 // ============================================================================= 

--- a/bootstrap/consts.h
+++ b/bootstrap/consts.h
@@ -187,35 +187,51 @@
 #define INTERRUPT_PIT_VEC   0x20
 
 // Offsets for the interrupt frame constructed by the generic interrupt handler.
+// (QWORD) R15 value at the time of the interrupt.
+#define INT_FRAME_SAVED_R15_OFF     (0 * 0x8)
+// (QWORD) R14 value at the time of the interrupt.
+#define INT_FRAME_SAVED_R14_OFF     (1 * 0x8)
+// (QWORD) R13 value at the time of the interrupt.
+#define INT_FRAME_SAVED_R13_OFF     (2 * 0x8)
+// (QWORD) R12 value at the time of the interrupt.
+#define INT_FRAME_SAVED_R12_OFF     (3 * 0x8)
+// (QWORD) R11 value at the time of the interrupt.
+#define INT_FRAME_SAVED_R11_OFF     (4 * 0x8)
+// (QWORD) R10 value at the time of the interrupt.
+#define INT_FRAME_SAVED_R10_OFF     (5 * 0x8)
+// (QWORD) R9 value at the time of the interrupt.
+#define INT_FRAME_SAVED_R9_OFF      (6 * 0x8)
+// (QWORD) R8 value at the time of the interrupt.
+#define INT_FRAME_SAVED_R8_OFF      (7 * 0x8)
 // (QWORD) RDI value at the time of the interrupt.
-#define INT_FRAME_SAVED_RDI_OFF     0x00
+#define INT_FRAME_SAVED_RDI_OFF     (8 * 0x8)
 // (QWORD) RSI value at the time of the interrupt.
-#define INT_FRAME_SAVED_RSI_OFF     0x08
+#define INT_FRAME_SAVED_RSI_OFF     (9 * 0x8)
 // (QWORD) RBP value at the time of the interrupt.
-#define INT_FRAME_SAVED_RBP_OFF     0x10
+#define INT_FRAME_SAVED_RBP_OFF     (10 * 0x8)
 // (QWORD) RBX value at the time of the interrupt.
-#define INT_FRAME_SAVED_RBX_OFF     0x18
+#define INT_FRAME_SAVED_RBX_OFF     (11 * 0x8)
 // (QWORD) RDX value at the time of the interrupt.
-#define INT_FRAME_SAVED_RDX_OFF     0x20
+#define INT_FRAME_SAVED_RDX_OFF     (12 * 0x8)
 // (QWORD) RCX value at the time of the interrupt.
-#define INT_FRAME_SAVED_RCX_OFF     0x28
+#define INT_FRAME_SAVED_RCX_OFF     (13 * 0x8)
 // (QWORD) RAX value at the time of the interrupt.
-#define INT_FRAME_SAVED_RAX_OFF     0x30
+#define INT_FRAME_SAVED_RAX_OFF     (14 * 0x8)
 // (QWORD) Vector of the interrupt.
-#define INT_FRAME_VECTOR_OFF        0x38
+#define INT_FRAME_VECTOR_OFF        (15 * 0x8)
 // (QWORD) Error code of the interrupt. For vector that do not push error code
 // or software interrupts this value is a placeholder.
-#define INT_FRAME_ERROR_CODE_OFF    0x40
+#define INT_FRAME_ERROR_CODE_OFF    (16 * 0x8)
 // (QWORD) RIP at the time of the interrupt.
-#define INT_FRAME_RIP_OFF           0x48
+#define INT_FRAME_RIP_OFF           (17 * 0x8)
 // (QWORD) CS at the time of the interrupt.
-#define INT_FRAME_CS_OFF            0x50
+#define INT_FRAME_CS_OFF            (18 * 0x8)
 // (QWORD) RFLAGS at the time of the interrupt.
-#define INT_FRAME_RFLAGS_OFF        0x58
+#define INT_FRAME_RFLAGS_OFF        (19 * 0x8)
 // (QWORD) RSP at the time of the interrupt.
-#define INT_FRAME_RSP_OFF           0x60
+#define INT_FRAME_RSP_OFF           (20 * 0x8)
 // (QWORD) SS at the time of the interrupt.
-#define INT_FRAME_SS_OFF            0x68
+#define INT_FRAME_SS_OFF            (21 * 0x8)
 // ============================================================================= 
 
 // ============================================================================= 

--- a/bootstrap/consts.h
+++ b/bootstrap/consts.h
@@ -259,4 +259,6 @@
 #define SYSNR_TEST1         0x1
 // Syscall to get the TSC's frequency in Hz.
 #define SYSNR_GET_TSC_FREQ  0x2
+// Syscall to print a NUL-terminated string in the serial console.
+#define SYSNR_LOG_SERIAL    0x3
 // ============================================================================= 

--- a/bootstrap/elf_parser.S
+++ b/bootstrap/elf_parser.S
@@ -6,6 +6,18 @@
 
 .intel_syntax   noprefix
 
+.section .data
+// FIXME: Since we only have a single process for now this is where we store the
+// program break.
+// The program break indicate the lowest address of the heap.
+.global PROGRAM_BREAK
+PROGRAM_BREAK:
+.quad   0x0
+// The original program break. We cannot go under this value.
+.global ORIG_PROGRAM_BREAK
+ORIG_PROGRAM_BREAK:
+.quad   0x0
+
 // Offsets of different fields (those that we use) of a 64-bit ELF header.
 .set ELF_HEADER_SIZE, 0x40
 // Magic number.
@@ -196,6 +208,20 @@ copy:
 .memsz_zero:
     WARN64("Empty segment in ELF file\n")
 .process_done:
+
+    // Update the program break.
+    mov     rax, [rbx + P_VADDR]
+    add     rax, [rbx + P_MEMSZ]
+    cmp     rax, [PROGRAM_BREAK]
+    jbe     0f
+    // The segment went above PROGRAM_BREAK. Update it.
+    // Make sure the program break is page aligned.
+    and     rax, ~(PAGE_SIZE - 1)
+    add     rax, PAGE_SIZE
+    mov     [PROGRAM_BREAK], rax
+    mov     [ORIG_PROGRAM_BREAK], rax
+0:
+
     pop     r13
     pop     r12
     pop     rbx
@@ -338,6 +364,10 @@ ASM_FUNC_DEF64(parse_elf_from_ram):
     call    parse_prog_header_table
 
     INFO64("Program Header Table parsed\n")
+
+    push    [PROGRAM_BREAK]
+    INFO64("Program break is @ %q\n")
+    add     esp, 8
 
     mov     rax, [rbx + E_ENTRY]
 

--- a/bootstrap/elf_parser.S
+++ b/bootstrap/elf_parser.S
@@ -107,7 +107,7 @@ ASM_FUNC_DEF64(check_elf):
 .set P_FILESZ, 0x20
 // Size of the segment in virtual memory. If this is bigger than P_FILESZ then
 // any additional bytes after the initialized content should be 0.
-.set P_MEMSZ, 0x20
+.set P_MEMSZ, 0x28
 // Size of a Program Header Table entry in bytes.
 .set PHENTSIZE, 0x38
 
@@ -190,7 +190,7 @@ copy:
     xor     al, al
     mov     rcx, [rbx + P_MEMSZ]
     sub     rcx, [rbx + P_FILESZ]
-    rep     movsb
+    rep     stosb
     jmp     .process_done
 
 .memsz_zero:

--- a/bootstrap/frame_alloc.S
+++ b/bootstrap/frame_alloc.S
@@ -177,138 +177,155 @@ ASM_FUNC_DEF32(init_frame_allocator):
     ret
 
 // =============================================================================
-// Get a free physical frame. Since this routine is for 32-bit mode it will
-// return a frame under 4GiB.
-// @return (EAX) Physical address of the allocated frame.
+// Allocate multiple contiguous physical frames at once.
+// @param N: The number of physical frames to allocate. This must be under 2^20.
+// @return (EAX): The address of the first frame allocated. If no frame can be
+// allocated, this routine will return NO_FRAME.
 // =============================================================================
-ASM_FUNC_DEF32(allocate_frame32):
+ASM_FUNC_DEF32(allocate_n_frames32):
     push    ebp
     mov     ebp, esp
-    push    ebx
-    push    esi
 
+    // Local var:
+    //  EBP - 0x8: (QWORD) requested size in a QWORD.
+    push    0x0
+    push    [ebp + 0x8]
+
+    // Check N against the maximum possible.
+    cmp     DWORD PTR [ebp + 0x8], (1 << 20)
+    jb      0f
+    PANIC32("allocate_n_frames32: N is too big!\n")
+0:
+
+    // Check that the head of the linked list is not above 4GiB.
     cmp     DWORD PTR [FRAME_ALLOC_HEAD + 4], 0x0
     je      0f
-    PANIC32("First node is above 4GiB\n")
+    PANIC32("allocate_n_frames32: First node in linked list is above 4GiB\n")
 0:
 
-    // EBX = Pointer on the head node.
+    push    ebx
+    push    edi
+    push    esi
+
+    // Traverse the linked list to find a group containing enough frames.
+    // EBX = Pointer on current group.
     mov     ebx, [FRAME_ALLOC_HEAD]
-
-    // Assert that the start address is < 4GiB. We could instead look at the
-    // next node, but then it would make things more complicated if we need to
-    // remove it. By doing this way we can only remove the head of the list
-    // which is simpler.
+    // EDI = Pointer on the next pointer of the previous node.
+    lea     edi, [FRAME_ALLOC_HEAD]
+.alloc_n_loop:
+    // Check if the base addres of the current group is above 4GiB.
     cmp     DWORD PTR [ebx + NODE_ADDR_OFF + 4], 0x0
-    je      0f
-    PANIC32("First node has start address above 4GiB\n")
-0:
+    jne     .alloc_n_next
 
-    // Assert that the size is > 0.
-    cmp     DWORD PTR [ebx + NODE_SIZE_OFF + 4], 0x0
-    jne     0f
-    cmp     DWORD PTR [ebx + NODE_SIZE_OFF], 0x0
-    jne     0f
-    // Size is zero. This should never happen.
-    PANIC32("Element of allocator's linked list has a size of 0\n")
-0:
-
-    // ESI = Address of the allocated frame.
-    mov     esi, [ebx + NODE_ADDR_OFF]
-
-    // Increase start address by PAGE_SIZE.
-    push    0x0
-    push    PAGE_SIZE
-    push    esp
-    lea     eax, [ebx + NODE_ADDR_OFF]
-    push    eax
-    push    eax
-    call    add64
-    add     esp, 0x14
-
-    // Decrease size by 1. 
-    push    0x0
-    push    0x1
-    push    esp
+    // Node starts under 4GiB and thus is available for 32-bit frame allocation.
+    // Check the size of the current group against the requested size.
     lea     eax, [ebx + NODE_SIZE_OFF]
     push    eax
+    lea     eax, [ebp - 0x8]
+    push    eax
+    call    cmp64
+    add     esp, 0x8
+    // If EAX == ARITH64_ABOVE then the requested size is bigger than the
+    // current group. This will not work, try the next group.
+    cmp     eax, ARITH64_ABOVE
+    je      .alloc_n_next
+
+    // The current group is big enough to perform the allocation. Now make sure
+    // that the base address + the size does not go over the 4GiB limit. Since
+    // we know that the top 32-bit of the base address are 0 we can simply add
+    // the size to the lower 32-bit and check the Carry Flag. If CF is set then
+    // the region goes over 4GiB and therefore cannot be used for this
+    // allocation.
+    // EAX = Address of the last byte of the allocation.
+    mov     eax, [ebx + NODE_ADDR_OFF]
+    mov     ecx, [ebp + 0x8]
+    shl     ecx, 12
+    // Dec here because we want the address of the last valid byte.
+    dec     ecx
+    add     eax, ecx
+    jc      .alloc_n_next
+
+    // This group passed all the checks, we can proceed with the allocation.
+    // ESI = Start address of the allocated frames = base address of the group.
+    // Once again this address is below 4GiB hence we only load the first
+    // 32-bits.
+    mov     esi, [ebx + NODE_ADDR_OFF]
+
+    // Update the base address of the group by advancing it by N * PAGE_SIZE.
+    lea     eax, [ebp - 0x8]
+    shl     DWORD PTR [eax], 12
+    push    eax
+    lea     eax, [ebx + NODE_ADDR_OFF]
+    push    eax
+    // In-place update.
+    push    eax
+    call    add64
+    add     esp, 0xC
+    shr     DWORD PTR [ebp - 0x8], 12
+
+    // Update the size of the group.
+    lea     eax, [ebp - 0x8]
+    push    eax
+    lea     eax, [ebx + NODE_SIZE_OFF]
+    push    eax
+    // Update in place.
     push    eax
     call    sub64
-    add     esp, 4
-    // Keep the same arg and compare the current size with 0x1
-    call    cmp64
-    add     esp, 0x10
+    add     esp, 0xC
 
-    cmp     eax, ARITH64_BELOW
-    jne     .alloc_done
+    // Check if size of group is now zero.
+    cmp     DWORD PTR [ebx + NODE_SIZE_OFF + 4], 0x0
+    jne     .alloc_n_done
+    cmp     DWORD PTR [ebx + NODE_SIZE_OFF], 0x0
+    jne     .alloc_n_done
 
-    // Group is empty, remove it from the linked-list.
-    mov     eax, [ebx + NODE_NEXT_OFF + 4]
-    mov     [FRAME_ALLOC_HEAD + 4], eax
+    // Size is zero, we need to remove the group. Update the next pointer of the
+    // previous node to point to the next node of the current one.
     mov     eax, [ebx + NODE_NEXT_OFF]
-    mov     [FRAME_ALLOC_HEAD], eax
-    
-.alloc_done:
-    // EBX = Address of the freshly allocated frame.
-    mov     eax, esi
+    mov     [edi], eax
+    jmp     .alloc_n_done
 
+.alloc_n_next:
+    // Traverse the linked list.
+    cmp     DWORD PTR [ebx + NODE_NEXT_OFF + 4], 0x0
+    je      0f
+    PANIC32("allocate_n_frames32: Node of linked list above 4GiB\n")
+0:
+
+    lea     edi, [ebx + NODE_NEXT_OFF]
+    mov     ebx, [ebx + NODE_NEXT_OFF]
+
+    test    ebx, ebx
+    jnz     .alloc_n_loop
+    // Reached the end of the linked list and couldn't find a suitable group.
+    // The allocation failed.
+    mov     esi, NO_FRAME
+
+.alloc_n_done:
+    // Allocation is done, ESI points to the start of the allocated physical
+    // RAM.
+    mov     eax, esi
     pop     esi
+    pop     edi
     pop     ebx
+
+    // Cleanup local var(s).
+    add     esp, 8
+
     leave
     ret
 
 // =============================================================================
-// Allocate N contiguous frames.
-// @param N : The number of frames.
-// @return (EAX) The address of the first frame of the contiguous region.
-// FIXME: This is an extremely naive implementation that assumes the first group
-// of free frame contains at least N frames. This is ok in practice because the
-// first group is at 1MiB (assuming the BIOS mem map is sorted) and there is a
-// lot of free memory starting at 1MiB.
+// Get a free physical frame. Since this routine is for 32-bit mode it will
+// return a frame under 4GiB. This is equivalent to call allocate_n_frames32
+// with N = 1.
+// @return (EAX): The address of frame allocated. If no frame can be allocated,
+// this routine will return NO_FRAME.
 // =============================================================================
-ASM_FUNC_DEF32(allocate_contiguous_frames32):
-    push    ebp
-    mov     ebp, esp
-    push    ebx
-    push    edi
-
-    // EBX = Addr of last allocated frame.
-    xor     ebx, ebx
-    // EDI = Add of first frame.
-    xor     edi, edi
-    // ECX = Number of frames.
-    mov     ecx, [ebp + 0x8]
-
-.alloc_cont_loop:
-    push    ecx
-
-    call    allocate_frame32
-
-    // ECX = Addr of last frame.
-    mov     ecx, ebx
-    // Update addr of last frame.
-    mov     ebx, eax
-
-    // If this is the first iteration set EDI and skip the comparison.
-    test    edi, edi
-    jnz     0f
-    mov     edi, eax
-    jmp     .alloc_cont_loop_next
-0:
-    // Not first iteration, make sure EAX - ECX == PAGE_SIZE.
-    sub     eax, ecx
-    cmp     eax, PAGE_SIZE
-    je      .alloc_cont_loop_next
-    PANIC32("Could not allocate contiguous frames for ELF file\n") 
-
-.alloc_cont_loop_next:
-    pop     ecx
-    loop    .alloc_cont_loop
-
-    mov     eax, edi
-    pop     edi
-    pop     ebx
-    leave
+ASM_FUNC_DEF32(allocate_frame32):
+    push    0x1
+    call    allocate_n_frames32
+    add     esp, 4
     ret
 
 // =============================================================================

--- a/bootstrap/interrupt.S
+++ b/bootstrap/interrupt.S
@@ -392,12 +392,6 @@ ASM_FUNC_DEF64(generic_handler):
     // Replace the return address with the vector number computed.
     mov     [rbp + INT_FRAME_VECTOR_OFF], rax
 
-    push    [rbp + INT_FRAME_RIP_OFF]
-    push    [rbp + INT_FRAME_ERROR_CODE_OFF]
-    push    [rbp + INT_FRAME_VECTOR_OFF]
-    DEBUG64("INTERRUPT, vector = %b, error code = %q, RIP = %q\n")
-    mov     rsp, rbp
-
     // Step 4: Look up the INTERRUPT_CALLBACKS table for any callback for that
     // vector.
     // RCX = INTERRUPT_CALLBACKS[vector]
@@ -405,11 +399,20 @@ ASM_FUNC_DEF64(generic_handler):
     mov     rcx, [INTERRUPT_CALLBACKS]
     mov     rcx, [rcx + rax * 8]
     test    rcx, rcx
-    jz      0f
+    jz      ._generic_handler_no_callback
     mov     rdi, rbp
     call    rcx
-0:
+    jmp     ._generic_handler_eoi
 
+._generic_handler_no_callback:
+    // No handler, print a warning.
+    push    [rbp + INT_FRAME_RIP_OFF]
+    push    [rbp + INT_FRAME_ERROR_CODE_OFF]
+    push    [rbp + INT_FRAME_VECTOR_OFF]
+    WARN64("UNHANDLED INTERRUPT, vector = %b, error code = %q, RIP = %q\n")
+    mov     rsp, rbp
+
+._generic_handler_eoi:
     call    lapic_eoi
 
     // Interrupt has been handled, we are about to return to the interrputed

--- a/bootstrap/interrupt.S
+++ b/bootstrap/interrupt.S
@@ -1,0 +1,347 @@
+// This file contains all the state and routines related to interrupt
+// initialization and handling.
+// 
+// In x86_64, the processor uses the Interrupt Descriptor Table (IDT) to know
+// what handler to call for a given vector. Each IDT entry contains an `offset`
+// field which is the address of the handler.
+// Upon an interrupt, the processor pushes an interrupt frame onto the stack
+// containing info about the interrupted context (RIP, RSP, CS, SS, RFLAGS,
+// ...), looks up the handler for the vector into the IDT and jumps to it.
+// Unfortunately, the interrupt frame does _not_ contain the vector number. We
+// could define one handler per vector, and each handler would assume the vector
+// number, but this means a lot of code duplication. Instead, we use the
+// following architecture to reduce duplication:
+//  1. We still define one handler per vector, but all handlers are the same and
+// simply consist of a near CALL instruction to a `generic_handler`.
+//  2. Each handler is therefore 5 bytes long (1 byte opcode and 32-bit rel
+//  offset). All handlers are contiguous in memory, this means handlerN is at
+//  address handlers<N-1> + 5.
+//  3. When execution flow reaches the generic_handler, we can compute the
+//  vector number by using the return address pushed by the CALL instruction of
+//  the interrupt handler as follows:
+//      vector = ((ret_addr - &handler0) / 5) - 1.
+//  The rationale is that the return address will point to the instruction
+//  _after_ the CALL instruction of the handler that called the generic_handler.
+//  Each handler is 5-bytes long and they are contiguous/packed. The -1 is
+//  because the return address is the next instruction, and not the CALL
+//  instruction itself.
+//
+// In summary the interrupt handlers are arranged as follows:
+//        handler0:
+//            call    generic_handler
+//        handler1:
+//            call    generic_handler
+//        handler2:
+//            call    generic_handler
+//        ...
+//        handlerN:
+//            call    generic_handler
+//        ...
+//        generic_handler:
+//            ...
+// IDT entry i points to handleri.
+//
+// The goal of the generic_handler is to compute the vector number, save the
+// registers onto the stack, start the processing of the interrupt and later
+// return to the interrupted context.
+
+#include <asm_macros.h>
+#include <consts.h>
+
+.intel_syntax   noprefix
+
+// Data used throughout this file.
+.section .data
+// The IDT descriptor to use with the LIDT instruction. This descriptor contains
+// a 16-bit limit followed with the 8-byte linear address.
+IDT_DESC:
+.short  0x0
+// Linear address of the IDT.
+IDT_ADDR:
+.quad   0x0
+// Memory region containing all the interrupt handlers referenced by the IDT.
+HANDLERS_ARRAY:
+.quad   0x0
+
+// =============================================================================
+// Set an IDT entry. This routine will define an interrupt-gate with DPL = 0 and
+// the given handler address as offset.
+// @param (RDI): Index/vector of entry to set.
+// @param (RSI): Offset of interrupt handler to use for the entry.
+// =============================================================================
+ASM_FUNC_DEF64(_set_idt_entry):
+    push    rbp
+    mov     rbp, rsp
+
+    // RAX = Pointer on entry.
+    mov     rcx, rdi
+    shl     rcx, 4
+    mov     rax, [IDT_ADDR]
+    add     rax, rcx
+
+    // First DWORD: Set lower 16-bits of offset and segment selector.
+    // FIXME: The segment selector (64-bit code segment: 0x30) is hard-coded
+    // here. We should at least have a #define in consts.h.
+    mov     [rax], si
+    or      DWORD PTR [rax], (0x30 << 16)
+    add     rax, 4
+
+    // Second DWORD: Set Type, DPL and present bit. Leave IST to 0, we are not
+    // using this feature. Type 14 indicate a 64-bit interrupt gate. Upper
+    // 16-bit of the DWORD contain offset bits 16 though 31.
+    mov     [rax], esi
+    and     DWORD PTR [rax], 0xFFFF << 16
+    or      DWORD PTR [rax], (1 << 15) | (14 << 8)
+    add     rax, 4
+
+    // Third DWORD: Offset bit 32 through 63.
+    shr     rsi, 32
+    mov     DWORD PTR [rax], esi
+    add     rax, 4
+
+    // Fourth DWORD is reserved, put zero.
+    mov     DWORD PTR [rax], 0x0
+    
+    leave
+    ret
+
+// =============================================================================
+// Allocate and initialize the interrupt handlers for vectors 0 through
+// INTERRUPT_IDT_SIZE - 1 included. Each handler is a near call to the
+// generic_handler routine. Handlers are contiguous.
+// =============================================================================
+ASM_FUNC_DEF64(_generate_handlers):
+    push    rbp
+    mov     rbp, rsp
+
+    // Allocate the array of interrup handlers. Each handler is 5-bytes long (a
+    // near call with 32-bit relative offset).
+    // RAX = Pointer on array of handlers.
+    mov     rdi, INTERRUPT_IDT_SIZE
+    imul    rdi, rdi, 5
+    call    allocate_low_mem64
+    // Save the array of handlers.
+    mov     [HANDLERS_ARRAY], rax
+
+    // Now populate the array. Each handler is a near call of the form:
+    //  0xE8 <rel32>
+    // where rel32 is a 32-bit relative offset (relative to instruction after
+    // the call) in little-endian.
+    // RAX = Iterator.
+    // RCX = Number of handlers written.
+    xor     rcx, rcx
+    jmp     ._generate_handler_cond
+._generate_handler_loop:
+    // Set the near call rel32 opcode.
+    mov     BYTE PTR [rax], 0xE8 
+
+    // Compute the 32-bit displacement.
+    // EDX = Displacement = &generic_handler - (EAX + 5).
+    lea     edx, [generic_handler - 5]
+    sub     edx, eax
+    
+    // Store displacement.
+    mov     [rax + 1], edx
+._generate_handler_next:
+    // Advance iterator to next handler (5 bytes from the current one).
+    add     rax, 5
+    inc     rcx
+._generate_handler_cond:
+    // Check that RAX < 4GiB. This is because we use 32-bit arithmetic to
+    // compute the relative offsets in the loop.
+    mov     edx, eax
+    cmp     rax, rdx
+    je      0f
+    PANIC64("_generate_handlers: RAX is above 4GiB")
+0:
+    cmp     rcx, INTERRUPT_IDT_SIZE
+    jb      ._generate_handler_loop
+
+    leave
+    ret
+
+// =============================================================================
+// Allocate and fill up the IDT for entries 0 through INTERRUPT_IDT_SIZE - 1
+// included. This routine will allocate and initialize handlers as well.
+// =============================================================================
+ASM_FUNC_DEF64(_create_idt):
+    push    rbp
+    mov     rbp, rsp
+    push    rbx
+
+    // Allocate the IDT, each entry is 16-bytes.
+    // RAX = Address of IDT.
+    mov     rdi, INTERRUPT_IDT_SIZE
+    shl     rdi, 4
+    call    allocate_low_mem64
+    // Save the IDT address.
+    mov     [IDT_ADDR], rax
+    
+    // Allocate and initialize interrupt handlers. This will allocate the
+    // HANDLERS_ARRAY.
+    call    _generate_handlers
+
+    // Initialize each entry in the IDT to point to its corresponding handler in
+    // the HANDLERS_ARRAY.
+    // BL = Entry index.
+    xor     rbx, rbx
+    jmp     ._create_idt_cond
+._create_idt_loop:
+    // Call _set_idt_entry with index = BL and handler = Base + 5 * BL where
+    // base is the address of the HANDLERS_ARRAY.
+    movzx   rdi, bl
+    imul    rsi, rbx, 5
+    add     rsi, [HANDLERS_ARRAY]
+    call    _set_idt_entry
+._create_idt_next:
+    // Next iteration, inc the vector.
+    inc     bl
+._create_idt_cond:
+    cmp     bl, INTERRUPT_IDT_SIZE
+    jb      ._create_idt_loop
+
+    pop     rbx
+    leave
+    ret
+
+// =============================================================================
+// Initialize state related to interrupts, that is:
+//  - IDT
+//  - Interrupt handlers
+//  - IDTR
+// This routine will _NOT_ enable interrupts.
+// =============================================================================
+ASM_FUNC_DEF64(init_interrupt):
+    push    rbp
+    mov     rbp, rsp
+
+    // Allocate IDT and interrupt handlers.
+    call    _create_idt
+
+    // Initialize the IDT_DESC's limit.
+    mov     WORD PTR [IDT_DESC], (INTERRUPT_IDT_SIZE * 16) - 1
+
+    // Load the IDTR.
+    lidt    [IDT_DESC] 
+    INFO64("IDTR set\n")
+
+    leave
+    ret
+
+// =============================================================================
+// This is the generic interrupt handler. Every handler for any vector will call
+// this handler. This routine will figure out the vector of the interrupt, save
+// all GP registers, create an interrupt frame, and start the processing of the
+// interrupt.
+// =============================================================================
+ASM_FUNC_DEF64(generic_handler):
+    // In x86_64, interrupts will push information onto the stack, this
+    // information is also known as the interrupt frame (to avoid confusion we
+    // will refer to this as _hardware_ interrupt frame). This interrupt frame
+    // has the following layout:
+    //  RSP + 0x28  |   SS      | <- SS at the time of the interrupt.
+    //  RSP + 0x20  |   RSP     | <- RSP at the time of the interrupt.
+    //  RSP + 0x18  | RFLAGS    | <- RFLAGS at the time of the interrupt.
+    //  RSP + 0x10  |   CS      | <- CS at the time of the interrupt.
+    //  RSP + 0x08  |   RIP     | <- RIP at the time of the interrupt.
+    //  RSP + 0x00  | ERR CODE  | <- OPTIONAL depending on the interrupt vector.
+    //
+    // When the handler for a given vector called the generic_handler, it pushed
+    // a return address onto the stack. Therefore the stack would look as
+    // follows:
+    // Vector with error code:     Vector without error code:
+    //  RSP + 0x30  |   SS      |
+    //  RSP + 0x28  |   RSP     |   RSP + 0x28  |   SS      |
+    //  RSP + 0x20  | RFLAGS    |   RSP + 0x20  |   RSP     |
+    //  RSP + 0x18  |   CS      |   RSP + 0x18  | RFLAGS    |
+    //  RSP + 0x10  |   RIP     |   RSP + 0x10  |   CS      |
+    //  RSP + 0x08  | ERR CODE  |   RSP + 0x08  |   RIP     |
+    //  RSP + 0x00  | RET ADDR  |   RSP + 0x00  | RET ADDR  |
+    // The distinction between vectors with and without error code induce
+    // complexity since offsets will change. Additionally, it is the handler's
+    // responsibility to pop the error code from the stack before executing
+    // IRET.
+    //
+    // To keep things simple, the generic handler will modify the interrupt
+    // frame by adding a dummy error code to vectors that do not push one, so
+    // that every interrupt frame looks the same therefore offsets never change
+    // and there is no shenanigans required to check if we need to remove the
+    // error code before the IRET or not. Here we will always need to, since we
+    // add the dummy error code.  Therefore interrupt frames will _always_ have
+    // the layout described above with the error code.
+    //
+    // There is one problem to solve: we need to detect if the error code was
+    // pushed onto the stack or not, and if not push a dummy one. We could do
+    // that by computing the vector number and look up if this vector produces
+    // an error code, but we can be smarter:
+    // In x86_64, upon an interrupt the RSP is aligned to a 16-byte boundary
+    // _before_ pushing the hardware interrupt frame. Therefore, if an error
+    // code was pushed, the RET ADDR is _not_ 16-byte aligned, whereas if an
+    // error code was _not_ pushed, RET ADDR is 16-byte aligned. Therefore we
+    // can simply look at the current value of RSP, if it is 16-bytes aligned,
+    // then the error code is missing and we need to fixup the interrupt frame,
+    // otherwise the error code is present and nothing more needs to be done.
+    // This "smarter" way adds the benefit that it works with software
+    // interrupts raising vectors that would normally push an error code (SW
+    // interrupt never push error codes).
+
+    // Step 1: Fixup interrupt frames missing error code.
+    test    rsp, 0xF
+    jnz     0f
+    // The Stack Pointer is 16-bytes aligned, this means the error code is
+    // MISSING, we need to put a dummy one.
+    // Push the RET ADDR 8 bytes down the stack.
+    push    [rsp]
+    // Write the dummy error code in the QWORD above the return address. Now the
+    // stack is consistent with what we expect.
+    // Note: We use the magic number 0xC0DEC0DEC0DEC0DE to indicate that the
+    // interrupt did not push an error code.
+    mov     DWORD PTR [rsp + 0x8], 0xC0DEC0DE
+    mov     DWORD PTR [rsp + 0xC], 0xC0DEC0DE
+0:
+
+    // Step 2: Save all GP registers.
+    push    rax
+    push    rcx
+    push    rdx
+    push    rbx
+    push    rbp
+    push    rsi
+    push    rdi
+
+    // RBP = Interrupt frame.
+    mov     rbp, rsp
+
+    // Step 3: Compute the vector number. This is explained in the file-level
+    // comment.
+    // RAX = Interrupt vector = ((ret_addr - handler_base) / 5) - 1.
+    mov     rax, [rsp + 7 * 8]
+    sub     rax, [HANDLERS_ARRAY]
+    cqo
+    mov     rcx, 5
+    div     rcx
+    dec     rax
+    // Replace the return address with the vector number computed.
+    mov     [rbp + INT_FRAME_VECTOR_OFF], rax
+
+    // Step 4: Here we would typically handle the interrupt. For now simply log
+    // the interrupt.
+    push    [rbp + INT_FRAME_RIP_OFF]
+    push    [rbp + INT_FRAME_ERROR_CODE_OFF]
+    push    [rbp + INT_FRAME_VECTOR_OFF]
+    DEBUG64("INTERRUPT, vector = %b, error code = %q, RIP = %q\n")
+    mov     rsp, rbp
+
+    // Interrupt has been handled, we are about to return to the interrputed
+    // context. First restore GP registers.
+    pop     rdi
+    pop     rsi
+    pop     rbp
+    pop     rbx
+    pop     rdx
+    pop     rcx
+    pop     rax
+    // Get rid of the vector number and the error code.
+    add     rsp, 16
+    // Return to interrupted context.
+    iretq

--- a/bootstrap/interrupt.S
+++ b/bootstrap/interrupt.S
@@ -332,6 +332,8 @@ ASM_FUNC_DEF64(generic_handler):
     DEBUG64("INTERRUPT, vector = %b, error code = %q, RIP = %q\n")
     mov     rsp, rbp
 
+    call    lapic_eoi
+
     // Interrupt has been handled, we are about to return to the interrputed
     // context. First restore GP registers.
     pop     rdi

--- a/bootstrap/interrupt.S
+++ b/bootstrap/interrupt.S
@@ -44,6 +44,13 @@
 // The goal of the generic_handler is to compute the vector number, save the
 // registers onto the stack, start the processing of the interrupt and later
 // return to the interrupted context.
+//
+// Instead of processing any vector, the generic_handler delegates processing to
+// `interrupt callback`. An interrupt callback is a routine taking as argument
+// a pointer to an interrupt frame.
+// Interrupt callbacks are stored in a table indexed by vector number. When an
+// interrupt is raise, the generic_handler looks up the table and call the
+// callback, if any, passing as argument (RDI) a pointer to the interrupt frame.
 
 #include <asm_macros.h>
 #include <consts.h>
@@ -61,6 +68,13 @@ IDT_ADDR:
 .quad   0x0
 // Memory region containing all the interrupt handlers referenced by the IDT.
 HANDLERS_ARRAY:
+.quad   0x0
+
+// The INTERRUPT_CALLBACKS is an array of function pointer index by vector. When
+// the generic_handler processes a particular vector, it will lookup the
+// function in this table (at index = vector) and call it. Values of 0x0
+// indicate no callback is available for the given vector.
+INTERRUPT_CALLBACKS:
 .quad   0x0
 
 // =============================================================================
@@ -225,6 +239,60 @@ ASM_FUNC_DEF64(init_interrupt):
     lidt    [IDT_DESC] 
     INFO64("IDTR set\n")
 
+    // Allocate the array of callbacks.
+    mov     rdi, INTERRUPT_IDT_SIZE * 8
+    call    allocate_low_mem64
+    mov     [INTERRUPT_CALLBACKS], rax
+    // Zero the array to avoid calling garbage.
+    mov     rdi, rax
+    xor     rax, rax
+    mov     rcx, INTERRUPT_IDT_SIZE
+    rep     stosq
+
+    leave
+    ret
+
+// =============================================================================
+// Set the callback for a given interrupt vector.
+// @param (RDI): Vector to set callback for.
+// @param (RSI): Pointer on callback/routine.
+// =============================================================================
+ASM_FUNC_DEF64(set_interrupt_callback):
+    push    rbp
+    mov     rbp, rsp
+
+    // Make sure not to go out of bounds.
+    cmp     rdi, INTERRUPT_IDT_SIZE
+    jb      0f
+    PANIC64("set_interrupt_callback: Out-of-bounds vector")
+0:
+
+    // RAX = Pointer on entry in INTERRUPT_CALLBACKS
+    mov     rax, [INTERRUPT_CALLBACKS]
+    lea     rax, [rax + rdi * 8]
+
+    // Make sure there is no callback already registered. If this is the case
+    // this could be a bug or race condition.
+    cmp     QWORD PTR [rax], 0x0
+    je      0f
+    PANIC64("set_interrupt_callback: Overwritting callback")
+0:
+
+    // Register the new callback.
+    mov     [rax], rsi
+
+    leave
+    ret
+
+// =============================================================================
+// Remove the callback associated with a given interrupt vector.
+// @param (RDI): Vector to remove the callback for.
+// =============================================================================
+ASM_FUNC_DEF64(del_interrupt_callback):
+    push    rbp
+    mov     rbp, rsp
+    mov     rax, [INTERRUPT_CALLBACKS]
+    mov     QWORD PTR [rax + rdi * 8], 0x0
     leave
     ret
 
@@ -324,13 +392,23 @@ ASM_FUNC_DEF64(generic_handler):
     // Replace the return address with the vector number computed.
     mov     [rbp + INT_FRAME_VECTOR_OFF], rax
 
-    // Step 4: Here we would typically handle the interrupt. For now simply log
-    // the interrupt.
     push    [rbp + INT_FRAME_RIP_OFF]
     push    [rbp + INT_FRAME_ERROR_CODE_OFF]
     push    [rbp + INT_FRAME_VECTOR_OFF]
     DEBUG64("INTERRUPT, vector = %b, error code = %q, RIP = %q\n")
     mov     rsp, rbp
+
+    // Step 4: Look up the INTERRUPT_CALLBACKS table for any callback for that
+    // vector.
+    // RCX = INTERRUPT_CALLBACKS[vector]
+    mov     rax, [rbp + INT_FRAME_VECTOR_OFF]
+    mov     rcx, [INTERRUPT_CALLBACKS]
+    mov     rcx, [rcx + rax * 8]
+    test    rcx, rcx
+    jz      0f
+    mov     rdi, rbp
+    call    rcx
+0:
 
     call    lapic_eoi
 

--- a/bootstrap/interrupt.S
+++ b/bootstrap/interrupt.S
@@ -376,6 +376,14 @@ ASM_FUNC_DEF64(generic_handler):
     push    rbp
     push    rsi
     push    rdi
+    push    r8
+    push    r9
+    push    r10
+    push    r11
+    push    r12
+    push    r13
+    push    r14
+    push    r15
 
     // RBP = Interrupt frame.
     mov     rbp, rsp
@@ -383,7 +391,7 @@ ASM_FUNC_DEF64(generic_handler):
     // Step 3: Compute the vector number. This is explained in the file-level
     // comment.
     // RAX = Interrupt vector = ((ret_addr - handler_base) / 5) - 1.
-    mov     rax, [rsp + 7 * 8]
+    mov     rax, [rsp + 15 * 8]
     sub     rax, [HANDLERS_ARRAY]
     cqo
     mov     rcx, 5
@@ -417,6 +425,14 @@ ASM_FUNC_DEF64(generic_handler):
 
     // Interrupt has been handled, we are about to return to the interrputed
     // context. First restore GP registers.
+    pop     r15
+    pop     r14
+    pop     r13
+    pop     r12
+    pop     r11
+    pop     r10
+    pop     r9
+    pop     r8
     pop     rdi
     pop     rsi
     pop     rbp

--- a/bootstrap/ioapic.S
+++ b/bootstrap/ioapic.S
@@ -69,6 +69,74 @@ ASM_FUNC_DEF64(init_ioapic):
     ret
 
 // =============================================================================
+// Write a redirection entry in the redirection table.
+// @param (RDI): Index in the redirection table.
+// @param (RSI): Content of the entry.
+// =============================================================================
+ASM_FUNC_DEF64(_write_redir_entry):
+    push    rbp
+    mov     rbp, rsp
+
+    // RAX = IOAPIC.
+    mov     rax, [IOAPIC_ADDR]
+
+    // Write the new entry. The low DWORD should be written to IOREDTBLx and the
+    // high DWORD to IOREDTBLx+1. Although the specification is not clear about
+    // how to write those, we should probably write the high DWORD first, as the
+    // low DWORD could unmask the interrupt.
+    // CL = IOREDTBLx+1
+    mov     cl, dil
+    shl     cl, 1
+    add     cl, IOREDTBL0 + 1
+
+    // Write high DWORD.
+    mov     rdx, rsi
+    shr     rdx, 32
+    mov     BYTE PTR [rax + IOREGSEL], cl
+    mov     [rax + IOWIN], edx
+
+    // Write low DWORD.
+    dec     cl
+    shr     rdx, 32
+    mov     BYTE PTR [rax + IOREGSEL], cl
+    mov     [rax + IOWIN], esi
+
+    leave
+    ret
+
+// =============================================================================
+// Get the source index/vector for a given IRQ number.
+// @param (RDI): The IRQ to convert.
+// @param (RAX): The I/O APIC source vector.
+// =============================================================================
+ASM_FUNC_DEF64(_get_source_for_irq):
+    push    rbp
+    mov     rbp, rsp
+    push    rbx
+
+    // Check that this is a correct IRQ.
+    cmp     rdi, 0x10
+    jb      0f
+    PANIC64("_get_source_for_irq: Invalid IRQ")
+0:
+
+    // Check that the IRQ number is within the range of the redirection table.
+    cmp     dil, [ioapic_max_redir_entry]
+    jbe     0f
+    PANIC64("_get_source_for_irq: IRQ number is outside bounds of table")
+0:
+
+    // Get the mapping from the IRQ_REDIR array.    
+    lea     rbx, [IRQ_REDIR]
+    mov     al, dil
+    xlatb 
+    movzx   rax, al
+
+    pop     rbx
+    leave
+    ret
+
+// =============================================================================
 // Map a legacy IRQ number to a vector. Subsequent interrupts on this IRQ will
 // raise an interrupt with the given vector on the current cpu.
 // @param (RDI): Legacy IRQ number.
@@ -77,13 +145,6 @@ ASM_FUNC_DEF64(init_ioapic):
 ASM_FUNC_DEF64(ioapic_redir_legacy_irq):
     push    rbp
     mov     rbp, rsp
-    push    rbx
-
-    // Check that the IRQ number is within the range of the redirection table.
-    cmp     dil, [ioapic_max_redir_entry]
-    jbe     0f
-    PANIC64("ioapic_redir_legacy_irq: IRQ number is outside bounds of table")
-0:
 
     push    rsi
     push    rdi
@@ -91,15 +152,9 @@ ASM_FUNC_DEF64(ioapic_redir_legacy_irq):
     pop     rdi
     pop     rsi
 
-    // The IRQ may not be identity-mapped to the I/O APIC. Look up the IRQ_REDIR
-    // table from ACPI to use the correct source.
-    lea     rbx, [IRQ_REDIR]
-    mov     al, dil
-    xlatb 
-    mov     dil, al
-
-    // RBX = IOAPIC.
-    mov     rbx, [IOAPIC_ADDR]
+    // RDI already contains IRQ number.
+    call    _get_source_for_irq
+    mov     rdi, rax
 
     // Compute the value to write into the redirection table.
     // RAX = entry.
@@ -115,27 +170,28 @@ ASM_FUNC_DEF64(ioapic_redir_legacy_irq):
     xor     rax, rax
     mov     al, sil
 
-    // Write the new entry. The low DWORD should be written to IOREDTBLx and the
-    // high DWORD to IOREDTBLx+1. Although the specification is not clear about
-    // how to write those, we should probably write the high DWORD first, as the
-    // low DWORD will unmask the interrupt.
-    // CL = IOREDTBLx+1
-    mov     cl, dil
-    shl     cl, 1
-    add     cl, IOREDTBL0 + 1
+    // RDI already has the entry index.
+    mov     rsi, rax
+    call    _write_redir_entry
 
-    // Write high DWORD.
-    mov     rdx, rax
-    shr     rdx, 32
-    mov     BYTE PTR [rbx + IOREGSEL], cl
-    mov     [rbx + IOWIN], edx
+    leave
+    ret
 
-    // Write low DWORD.
-    dec     cl
-    shr     rdx, 32
-    mov     BYTE PTR [rbx + IOREGSEL], cl
-    mov     [rbx + IOWIN], eax
+// =============================================================================
+// Mask an IRQ from the I/O APIC.
+// @param (RDI): The IRQ number to mask.
+// =============================================================================
+ASM_FUNC_DEF64(ioapic_mask_legacy_irq):
+    push    rbp
+    mov     rbp, rsp
 
-    pop     rbx
+    // Get the index from the IRQ number.
+    call    _get_source_for_irq
+    mov     rdi, rax
+
+    // Bit 16 masks the interrupt.
+    mov     rsi, (1 << 16)
+    call    _write_redir_entry
+
     leave
     ret

--- a/bootstrap/ioapic.S
+++ b/bootstrap/ioapic.S
@@ -1,0 +1,141 @@
+// This file contains routines and state related to I/O APIC.
+
+#include <asm_macros.h>
+#include <consts.h>
+
+.intel_syntax   noprefix
+
+.section .data
+// The max index in the redirection table.
+ioapic_max_redir_entry:
+.byte   0x0
+
+// Offset of the two registers of the IO APIC.
+.set IOREGSEL, 0x0
+.set IOWIN, 0x10
+
+// The offsets of the IOAPIC registers.
+.set IOAPICID, 0x0
+.set IOAPICVER, 0x1
+.set IOAPICARB, 0x2
+.set IOREDTBL0, 0x10
+
+// =============================================================================
+// Initialize the I/O APIC.
+// =============================================================================
+ASM_FUNC_DEF64(init_ioapic):
+    push    rbp
+    mov     rbp, rsp
+    push    rbx
+
+    // Check that the address of the IOAPIC was found while parsing ACPI tables.
+    // RBX = Physical address of IO APIC.
+    mov     rbx, [IOAPIC_ADDR]
+    test    rbx, rbx
+    jnz     0f
+    PANIC64("init_ioapic: IOAPIC_ADDR is 0x0. Did you parse ACPI tables ?")
+0:
+    push    rbx
+    INFO64("Initializing I/O APIC @ %q\n")
+    pop     rbx
+
+    // We need to map the I/O APIC to virtual address space. Use an ID mapping
+    // to avoid confusions.
+    mov     rdi, rbx
+    mov     rsi, rbx
+    // We only need to map the two memory map registers.
+    mov     rdx, 0x14
+    mov     rcx, (MAP_WRITE | MAP_CACHE_DISABLE | MAP_WRITE_THROUGH)
+    call    map
+
+    // We can now use the IOAPIC.
+    // Read the version and the maximum number of redirection entries.
+    mov     BYTE PTR [rbx + IOREGSEL], IOAPICVER
+    mov     eax, [rbx + IOWIN]
+
+    // Save max redirection entry.
+    mov     ecx, eax
+    shr     ecx, 16
+    mov     [ioapic_max_redir_entry], cl 
+
+    push    rcx
+    push    rax
+    INFO64("I/O APIC is version %b, max redirection entry = %b\n")
+    pop     rax
+    pop     rcx
+
+    pop     rbx
+    leave
+    ret
+
+// =============================================================================
+// Map a legacy IRQ number to a vector. Subsequent interrupts on this IRQ will
+// raise an interrupt with the given vector on the current cpu.
+// @param (RDI): Legacy IRQ number.
+// @param (RSI): Vector to redirect to.
+// =============================================================================
+ASM_FUNC_DEF64(ioapic_redir_legacy_irq):
+    push    rbp
+    mov     rbp, rsp
+    push    rbx
+
+    // Check that the IRQ number is within the range of the redirection table.
+    cmp     dil, [ioapic_max_redir_entry]
+    jbe     0f
+    PANIC64("ioapic_redir_legacy_irq: IRQ number is outside bounds of table")
+0:
+
+    push    rsi
+    push    rdi
+    INFO64("ioapic_redir_legacy_irq: Redirecting IRQ %b => vector %b\n")
+    pop     rdi
+    pop     rsi
+
+    // The IRQ may not be identity-mapped to the I/O APIC. Look up the IRQ_REDIR
+    // table from ACPI to use the correct source.
+    lea     rbx, [IRQ_REDIR]
+    mov     al, dil
+    xlatb 
+    mov     dil, al
+
+    // RBX = IOAPIC.
+    mov     rbx, [IOAPIC_ADDR]
+
+    // Compute the value to write into the redirection table.
+    // RAX = entry.
+    // FIXME: For now we leave everything to 0, except the vector, this means:
+    //  - Delivery mode = Fixed
+    //  - Destination mode = Physical
+    //  - Polarity = High active
+    //  - Trigger mode = edge sensitive
+    //  - Interrupt unmasked
+    //  - Destination = APIC ID 0.
+    // FIXME: The destination is always cpu 0.
+    // In practice this is working just fine.
+    xor     rax, rax
+    mov     al, sil
+
+    // Write the new entry. The low DWORD should be written to IOREDTBLx and the
+    // high DWORD to IOREDTBLx+1. Although the specification is not clear about
+    // how to write those, we should probably write the high DWORD first, as the
+    // low DWORD will unmask the interrupt.
+    // CL = IOREDTBLx+1
+    mov     cl, dil
+    shl     cl, 1
+    add     cl, IOREDTBL0 + 1
+
+    // Write high DWORD.
+    mov     rdx, rax
+    shr     rdx, 32
+    mov     BYTE PTR [rbx + IOREGSEL], cl
+    mov     [rbx + IOWIN], edx
+
+    // Write low DWORD.
+    dec     cl
+    shr     rdx, 32
+    mov     BYTE PTR [rbx + IOREGSEL], cl
+    mov     [rbx + IOWIN], eax
+
+    pop     rbx
+    leave
+    ret

--- a/bootstrap/lapic.S
+++ b/bootstrap/lapic.S
@@ -1,0 +1,35 @@
+// This file contains routines and state related to the Local APIC.
+
+#include <asm_macros.h>
+#include <consts.h>
+
+.intel_syntax   noprefix
+
+// LAPIC Registers offsets.
+// End-Of-Interrupt register.
+.set LAPIC_REG_EOI, 0xB0
+
+// =============================================================================
+// Initialize the Local APIC of the current cpu.
+// =============================================================================
+ASM_FUNC_DEF64(init_lapic):
+    push    rbp
+    mov     rbp, rsp
+
+    // Map the LAPIC to virtual memory, use ID mapping to avoid confusion.
+    mov     rdi, [LAPIC_ADDR]
+    mov     rsi, rdi
+    mov     rdx, (MAP_WRITE | MAP_CACHE_DISABLE | MAP_WRITE_THROUGH)
+    call    map_frame
+
+    leave
+    ret
+
+// =============================================================================
+// Indicate the End-Of-Interrupt to the Local APIC.
+// =============================================================================
+ASM_FUNC_DEF64(lapic_eoi):
+    mov     rax, [LAPIC_ADDR]
+    // Any value works.
+    mov     DWORD PTR [rax + LAPIC_REG_EOI], 0x0
+    ret

--- a/bootstrap/lapic.S
+++ b/bootstrap/lapic.S
@@ -8,9 +8,19 @@
 // LAPIC Registers offsets.
 // End-Of-Interrupt register.
 .set LAPIC_REG_EOI, 0xB0
+.set LAPIC_REG_INIT_COUNT, 0x380
+.set LAPIC_REG_CURR_COUNT, 0x390
+// Divide Configuration Register (for timer).
+.set LAPIC_REG_DIV_CONF, 0x3E0
+
+.section .data
+// The frequency of the LAPIC Timer in Hz.
+LAPIC_FREQ:
+.quad   0x0
 
 // =============================================================================
-// Initialize the Local APIC of the current cpu.
+// Initialize the Local APIC of the current cpu. This routine will calibrate the
+// frequency of the timer as well.
 // =============================================================================
 ASM_FUNC_DEF64(init_lapic):
     push    rbp
@@ -22,7 +32,56 @@ ASM_FUNC_DEF64(init_lapic):
     mov     rdx, (MAP_WRITE | MAP_CACHE_DISABLE | MAP_WRITE_THROUGH)
     call    map_frame
 
+    // Initialize the divide configuration register to use 1 as divisor. This
+    // MUST NEVER CHANGE, since this is the value that we will calibrate.
+    mov     eax, DWORD PTR [rbx + LAPIC_REG_DIV_CONF]
+    or      eax, (1 << 3) | 3
+    mov     DWORD PTR [rbx + LAPIC_REG_DIV_CONF], eax
+
+    // Calibrate the LAPIC timer.
+    call    _calibrate_lapic_timer
+
     leave
+    ret
+
+// =============================================================================
+// Calibrate the LAPIC timer's frequency using the PIT. This routine will write
+// the frequency to LAPIC_FREQ.
+// =============================================================================
+ASM_FUNC_DEF64(_calibrate_lapic_timer):
+    push    rbp
+    mov     rbp, rsp
+
+    INFO64("Calibrating LAPIC timer frequency\n")
+
+    // RAX = Pointer to LAPIC.
+    mov     rax, [LAPIC_ADDR]
+
+    // Start LAPIC timer countdown. Set to maximum value.
+    mov     DWORD PTR [rax + LAPIC_REG_INIT_COUNT], ~0
+
+    lea     rdi, [_calibrate_lapic_timer_read_curr_count]
+    // RAX = LAPIC timer frequency.
+    call    calibrate_counter_with_pit
+    // Since the timer counts down, the result will be a negative frequency,
+    // negate it to get the real frequency.
+    neg     rax
+
+    mov     [LAPIC_FREQ], rax
+    push    rax
+    INFO64("LAPIC Timer freq = %q Hz\n")
+    add     esp, 8
+
+    leave
+    ret
+
+// =============================================================================
+// Helper routine used during calibration to read the current value of the LAPIC
+// timer.
+// =============================================================================
+ASM_FUNC_DEF64(_calibrate_lapic_timer_read_curr_count):
+    mov     rax, [LAPIC_ADDR]
+    mov     eax, [rax + LAPIC_REG_CURR_COUNT]
     ret
 
 // =============================================================================

--- a/bootstrap/lapic.S
+++ b/bootstrap/lapic.S
@@ -26,6 +26,12 @@ ASM_FUNC_DEF64(init_lapic):
     push    rbp
     mov     rbp, rsp
 
+    // Disable the legacy Programmable Interrupt Controller (PIC). Having PIC
+    // and APIC at the same time is just asking for trouble.
+    mov     al, 0xff
+    out     0xa1, al
+    out     0x21, al
+
     // Map the LAPIC to virtual memory, use ID mapping to avoid confusion.
     mov     rdi, [LAPIC_ADDR]
     mov     rsi, rdi

--- a/bootstrap/logging.S
+++ b/bootstrap/logging.S
@@ -135,7 +135,7 @@ putc_vga_buffer_cursor:
 // ============================================================================= 
 ASM_FUNC_DEF32(_putc32):
     push    [esp + 4]
-    call    putc_vga_buffer32
+    call    putc_serial32
     add     esp, 4
     ret
 

--- a/bootstrap/logging.S
+++ b/bootstrap/logging.S
@@ -130,6 +130,16 @@ putc_vga_buffer_cursor:
 .long   0x0
 
 // ============================================================================= 
+// Call the underlying putc implementation. For now only VGA is available.
+// @param (DWORD) The character to print.
+// ============================================================================= 
+ASM_FUNC_DEF32(_putc32):
+    push    [esp + 4]
+    call    putc_vga_buffer32
+    add     esp, 4
+    ret
+
+// ============================================================================= 
 // Output an hexadecimal value into the VGA buffer at the current cursor
 // position.
 // @param (DWORD) size: The number of bytes of the value.
@@ -143,12 +153,12 @@ ASM_FUNC_DEF32(_printf_output_hex32):
     
     // Put '0'.
     push    0x30
-    call    putc_vga_buffer32
+    call    _putc32
     add     esp, 4
 
     // Put 'x'.
     push    0x78
-    call    putc_vga_buffer32
+    call    _putc32
     add     esp, 4
 
     // Since x86 is little-endian, the byte following the "0x" will be the byte
@@ -168,8 +178,8 @@ ASM_FUNC_DEF32(_printf_output_hex32):
 
     // In order to output the correct representation of the byte, we need to do
     // some ASCII math on each half/4bits composing the byte.
-    // The goal here is to make two calls to putc_vga_buffer32 with the correct
-    // digit or letter.
+    // The goal here is to make two calls to _putc32 with the correct digit or
+    // letter.
     // The math is the same for each half, hence we have a small loop that will
     // execute twice, computing the digit/letter and pushing it onto the stack.
     xor     edx, edx
@@ -198,9 +208,9 @@ ASM_FUNC_DEF32(_printf_output_hex32):
     // At this point the stack contains:
     //  SP + 4 -> digit/letter of lower 4 bits of AL.
     //  SP     -> digit/letter of higher 4 bits of AL.
-    call    putc_vga_buffer32
+    call    _putc32
     add     esp, 4
-    call    putc_vga_buffer32
+    call    _putc32
     add     esp, 4
     
     // Move to previous byte.
@@ -253,7 +263,7 @@ ASM_FUNC_DEF32(printf32):
 
     // Regular character, simply output it.
     push    eax
-    call    putc_vga_buffer32
+    call    _putc32
     add     esp, 4
     jmp     3f
 

--- a/bootstrap/logging64.S
+++ b/bootstrap/logging64.S
@@ -99,6 +99,14 @@ ASM_FUNC_DEF64(putc_vga_buffer64):
     ret
 
 // ============================================================================= 
+// Call the underlying putc implementation. For now only VGA is available.
+// @param (DWORD) The character to print.
+// ============================================================================= 
+ASM_FUNC_DEF64(_putc64):
+    call    putc_vga_buffer64
+    ret
+
+// ============================================================================= 
 // Output an hexadecimal value into the VGA buffer at the current cursor
 // position.
 // @param (RDI) size: The number of bytes of the value.
@@ -114,11 +122,11 @@ ASM_FUNC_DEF64(_printf_output_hex64):
     push    rsi
     // Put '0'.
     mov     rdi, 0x30
-    call    putc_vga_buffer64
+    call    _putc64
 
     // Put 'x'.
     mov     rdi, 0x78
-    call    putc_vga_buffer64
+    call    _putc64
     pop     rsi
     pop     rdi
 
@@ -143,8 +151,8 @@ ASM_FUNC_DEF64(_printf_output_hex64):
 
     // In order to output the correct representation of the byte, we need to do
     // some ASCII math on each half/4bits composing the byte.
-    // The goal here is to make two calls to putc_vga_buffer64 with the correct
-    // digit or letter.
+    // The goal here is to make two calls to _putc64 with the correct digit or
+    // letter.
     // The math is the same for each half, hence we have a small loop that will
     // execute twice, computing the digit/letter and pushing it onto the stack.
     xor     rdx, rdx
@@ -174,9 +182,9 @@ ASM_FUNC_DEF64(_printf_output_hex64):
     //  RSP + 8 -> digit/letter of lower 4 bits of AL.
     //  RSP     -> digit/letter of higher 4 bits of AL.
     pop     rdi
-    call    putc_vga_buffer64
+    call    _putc64
     pop     rdi
-    call    putc_vga_buffer64
+    call    _putc64
     
     // Move to previous byte.
     rol     rbx, 8
@@ -224,7 +232,7 @@ ASM_FUNC_DEF64(printf64):
     // Regular character, simply output it.
     xor     rdi, rdi
     mov     dil, al
-    call    putc_vga_buffer64
+    call    _putc64
     jmp     .printf64_loop_continue
 
 .printf64_loop_subst:

--- a/bootstrap/logging64.S
+++ b/bootstrap/logging64.S
@@ -103,7 +103,7 @@ ASM_FUNC_DEF64(putc_vga_buffer64):
 // @param (DWORD) The character to print.
 // ============================================================================= 
 ASM_FUNC_DEF64(_putc64):
-    call    putc_vga_buffer64
+    call    putc_serial64
     ret
 
 // ============================================================================= 

--- a/bootstrap/long_mode.S
+++ b/bootstrap/long_mode.S
@@ -48,10 +48,15 @@ ASM_FUNC_DEF32(init_long_mode):
 
     mov     ecx, 4
     // Allocate the tables.
-0:
+.init_long_mode_alloc_loop:
     push    ecx
 
     call    allocate_frame32
+    cmp     eax, NO_FRAME
+    jne     0f
+    PANIC32("init_long_mode: Could not allocate page table structure\n")
+0:
+
     // EDX = Address of frame.
     mov     edx, eax
 
@@ -66,7 +71,7 @@ ASM_FUNC_DEF32(init_long_mode):
     
     // Push the frame address into the local vars.
     push    edx
-    loop    0b
+    loop    .init_long_mode_alloc_loop
 
     // Store the address of the PML4.
     mov     eax, [ebp - 0x4]

--- a/bootstrap/paging.S
+++ b/bootstrap/paging.S
@@ -262,6 +262,86 @@ ASM_FUNC_DEF64(map_frame):
     ret
 
 // =============================================================================
+// Map a memory region to virtual memory. This routine can map regions of
+// arbitrary length and address do not have to be page-aligned. However they
+// need to have the same offset within the page/frame.
+// @param (RDI): Virtual address to map to. This address does not have to be
+// page aligned, the routine will take care of this.
+// @param (RSI): Physical address to map. Not necessarily page aligned.
+// @param (RDX): The number of bytes to map, not necessarily a multiple of
+// PAGE_SIZE.
+// @param (RCX): The flags of the map.
+// =============================================================================
+ASM_FUNC_DEF64(map):
+    push    rbp
+    mov     rbp, rsp
+
+    push    rbx
+    push    r12
+    push    r13
+
+    // Make sure the virtual and physical addresses have the same offset withing
+    // the page.
+    mov     rax, (PAGE_SIZE - 1)
+    mov     r8, rdi
+    mov     r9, rsi
+    and     r8, rax
+    and     r9, rax
+    cmp     r8, r9
+    je      0f
+    PANIC64("map: virtual and physical addresses have different page offsets")
+0:
+
+    // RBX = Original virtual address (RDI).
+    mov     rbx, rdi
+
+    // R12 = Mapping flags.
+    mov     r12, rcx
+
+    // Make the addresses page-aligned.
+    mov     rax, ~(PAGE_SIZE - 1)
+    and     rdi, rax
+    and     rsi, rax
+
+    // RCX = number of page(s) to map.
+    mov     rcx, rbx
+    add     rcx, rdx
+    and     rcx, ~(PAGE_SIZE - 1)
+    sub     rcx, rdi
+    shr     rcx, 12
+    inc     rcx
+
+    // Now map the pages one-by-one.
+    // RBX = Next virtual address to use for the call to map_frame.
+    // R12 = Flags. (This was already done above).
+    // R13 = Next physical address to use for the call to map_frame.
+    mov     rbx, rdi
+    mov     r13, rsi
+0:
+    // Save loop counter.
+    push    rcx
+
+    // Map the next page/frame.
+    mov     rdi, rbx
+    mov     rsi, r13
+    mov     rdx, r12
+    call    map_frame
+
+    // Advance the virtual and physical pointer to the next page/frame to be
+    // mapped.
+    add     rbx, PAGE_SIZE
+    add     r13, PAGE_SIZE
+    pop     rcx
+    loop    0b
+    
+    // Mapping done.
+    pop     r13
+    pop     r12
+    pop     rbx
+    leave
+    ret
+
+// =============================================================================
 // Allocate a memory area in the current virtual address space. This routine
 // will allocate physical frames and map them contiguously in virtual memory
 // starting at a given address.

--- a/bootstrap/paging.S
+++ b/bootstrap/paging.S
@@ -84,13 +84,25 @@ ASM_FUNC_DEF64(_set_table_entry):
     // Check that this entry is not currently used.
     test    QWORD PTR [rdi], (1 << PRESENT_SHIFT)
     jz      .not_used
-    // This entry is marked as present, this means it is still in use.
+    // This entry is marked as present, this means it is still in use. We only
+    // allow to change the permission bits of an existing mapping, not where it
+    // points.
+    mov     rax, [rdi]
+    shr     rax, 12
+    mov     r8, rdx
+    shr     r8, 12
+    cmp     rax, r8
+    je      0f
+    // This call would change where the entry point, this is not allowed.
     PANIC64("_set_table_entry: Tried to overwrite an existing mapping\n")
 .not_used:
 
+    // Zero-out the entry in case it was used before.
+    mov     QWORD PTR [rdi], 0x0
+
     // Set address of next level table.
     or      [rdi], rdx
-    // Set present and write bits.
+    // Set present bits.
     or      QWORD PTR [rdi], (1 << PRESENT_SHIFT)
     // Set other flags.
     or      QWORD PTR [rdi], rcx

--- a/bootstrap/pit.S
+++ b/bootstrap/pit.S
@@ -1,0 +1,157 @@
+// This file contains helper routines to interact with the legacy Programmable
+// Interval Timer (PIT).
+// The main usage for the PIT is to calibrate frequencies of counters for which
+// frequency is not well defined, this can include: Time-Stamp Counter, LAPIC
+// timer, ... The `calibrate_counter_with_pit` routine provides a generic way to
+// estimate the frequency of a counter.
+
+#include <asm_macros.h>
+#include <consts.h>
+
+.intel_syntax   noprefix
+
+// The port for the data channel 0.
+.set CHAN0_DATA_PORT, 0x40
+// The command port of the PIT.
+.set MODE_CMD_PORT, 0x43
+
+// =============================================================================
+// Start the PIT with frequency PIT_FREQ. This routine will take care of
+// re-routing the legacy PIT IRQ to INTERRUPT_PIT_VEC and will ENABLE
+// interrupts.
+// Note: It is the responsibility of the caller to register the callback for
+// INTERRUPT_PIT_VEC.
+// =============================================================================
+ASM_FUNC_DEF64(start_pit):
+    push    rbp
+    mov     rbp, rsp
+
+    // Redirect PIT IRQ (0) to vector INTERRUPT_PIT_VEC.
+    xor     rdi, rdi
+    mov     rsi, INTERRUPT_PIT_VEC
+    call    ioapic_redir_legacy_irq
+
+    // Setup the PIT to fire an interrupt with frequency PIT_FREQ Hz.
+    mov     al, (0b11 << 4) | (0b010 << 1)
+    out     MODE_CMD_PORT, al
+    mov     ax, PIT_RELOAD_VAL
+    out     CHAN0_DATA_PORT, al
+    rol     ax, 8
+    // The second write to the data port will start the pit.
+    out     CHAN0_DATA_PORT, al
+
+    // Enable interrupts.
+    sti
+
+    leave
+    ret
+
+// =============================================================================
+// Stop the PIT. This routine masks the PIT IRQ on the I/O APIC. This routine
+// does _NOT_ disable interrupts.
+// =============================================================================
+ASM_FUNC_DEF64(stop_pit):
+    // TODO: Once we can mask IRQs on the I/O APIC we should call that here.
+    ret
+
+// Calibration related data. See below.
+.section .data
+// The number of iterations/interrupts received so far.
+_calibrate_counter_with_pit_iterations:
+.short  0x0
+// The maximum number of iterations/interrupts used to calibrate.
+.set CALIBRATE_WITH_PIT_MAX_ITE, 100
+
+// =============================================================================
+// Interrupt callback used during calibration. This routine simply increments
+// the _calibrate_counter_with_pit_iterations unless it is already equals to
+// CALIBRATE_WITH_PIT_MAX_ITE.
+// =============================================================================
+ASM_FUNC_DEF64(_calibrate_counter_with_pit_callback):
+    lea     rax, [_calibrate_counter_with_pit_iterations]
+    cmp     WORD PTR [rax], CALIBRATE_WITH_PIT_MAX_ITE
+    jae     0f
+    inc     WORD PTR [rax]
+0:
+    ret
+
+// =============================================================================
+// Calibrate an arbitrary counter using the PIT. The counter must be started
+// _PRIOR_ to calling this routine. This routine starts the PIT, waits for
+// CALIBRATE_WITH_PIT_MAX_ITE PIT interrupts to come in and finally computes the
+// counter's frequency by using the start and end value and the PIT frequence.
+// @param (RDI): Pointer on routine reading the current value of the counter
+// into RAX.
+// @return (RAX): The frequency of the counter in Hz.
+// =============================================================================
+ASM_FUNC_DEF64(calibrate_counter_with_pit):
+    push    rbp
+    mov     rbp, rsp
+    push    rbx
+    push    r12
+    push    r13
+
+    // RBX = read routine.
+    mov     rbx, rdi
+
+    mov     eax, (1000 * CALIBRATE_WITH_PIT_MAX_ITE / PIT_FREQ)
+    push    rax
+    INFO64("Performing calibration with PIT, expected time = %d ms\n")
+    add     esp, 8
+
+    // Register callback for interrupt INTERRUPT_PIT_VEC.
+    mov     rdi, INTERRUPT_PIT_VEC
+    lea     rsi, [_calibrate_counter_with_pit_callback]
+    call    set_interrupt_callback
+
+    // Reset _calibrate_counter_with_pit_iterations.
+    mov     WORD PTR [_calibrate_counter_with_pit_iterations], 0x0
+
+    // Start PIT.
+    call    start_pit
+
+    // Read the start value. We do this _after_ starting the PIT because it is
+    // likely that starting the PIT has a bigger overhead than reading the
+    // current value.
+    // R12 = Start value.
+    call    rbx
+    mov     r12, rax
+
+    // Wait for CALIBRATE_WITH_PIT_MAX_ITE iterrupts ...
+._calibrate_counter_with_pit_wait:
+    hlt
+    cmp     WORD PTR [_calibrate_counter_with_pit_iterations], \
+            CALIBRATE_WITH_PIT_MAX_ITE
+    jb      ._calibrate_counter_with_pit_wait
+
+    // Wait is over. Disable interrupts and read the end value.
+    cli
+    // R13 = End value.
+    call    rbx
+    mov     r13, rax
+
+    // Stop the PIT.
+    call    stop_pit
+
+    // Compute the frequency of the counter using the following equation:
+    //  F = (end - start) / (N / PIT_FREQ) = PIT_FREQ * (end - start) / NUM_ITE
+    //    = PIT_FREQ * (r13 - r12) / N
+    mov     rax, r13
+    sub     rax, r12
+    mov     rcx, PIT_FREQ
+    imul    rcx
+    mov     rcx, CALIBRATE_WITH_PIT_MAX_ITE
+    // RAX = Freq.
+    idiv    rcx
+
+    push    rax
+    // Delete the interrupt callback used for the calibration.
+    mov     rdi, INTERRUPT_PIT_VEC
+    call    del_interrupt_callback
+    pop     rax
+
+    pop     r13
+    pop     r12
+    pop     rbx
+    leave
+    ret

--- a/bootstrap/pit.S
+++ b/bootstrap/pit.S
@@ -51,7 +51,8 @@ ASM_FUNC_DEF64(start_pit):
 // does _NOT_ disable interrupts.
 // =============================================================================
 ASM_FUNC_DEF64(stop_pit):
-    // TODO: Once we can mask IRQs on the I/O APIC we should call that here.
+    xor     rdi, rdi
+    call    ioapic_mask_legacy_irq
     ret
 
 // Calibration related data. See below.

--- a/bootstrap/serial.S
+++ b/bootstrap/serial.S
@@ -1,0 +1,136 @@
+// This file contains routines related to outputing to the serial console.
+
+#include <asm_macros.h>
+#include <consts.h>
+
+.intel_syntax   noprefix
+
+// The port number of COM0. This should be somewhat reliable. As long as it
+// works under Qemu it is enough.
+.set COM_PORT, 0x3F8
+// The maximum baud rate.
+.set MAX_BAUD_RATE, 115200
+// The requested baud rate.
+.set BAUD_RATE, 38400
+// The divisor to be used for the rate.
+.set BAUD_DIV, MAX_BAUD_RATE / BAUD_RATE
+
+// The following are the offset of the "registers".
+// Data registers. This is when DLAB is 0.
+.set SERIAL_REG_DATA, 0x0
+// When DLAB is 1 this becomes the register holding the lower 8 bits of the
+// divisor.
+.set SERIAL_REG_BAUD_LSB, 0x0
+// When DLAB = 1 this is the register holding the upper byte of the divisor.
+.set SERIAL_REG_BAUD_MSB, 0x1
+// Line control register.
+.set SERIAL_REG_LINE_CTRL, 0x3
+// Line status register.
+.set SERIAL_REG_LINE_STAT, 0x5
+
+// ============================================================================= 
+// Initialize COM0 for serial output.
+// ============================================================================= 
+ASM_FUNC_DEF32(init_serial):
+    push    ebp
+    mov     ebp, esp
+
+    // First set the baud rate divisor.
+    // Set DLAB bit.
+    mov     dx, COM_PORT + SERIAL_REG_LINE_CTRL
+    in      al, dx
+    or      al, (1 << 7)
+    out     dx, al
+
+    // Set divisor.
+    mov     dx, COM_PORT + SERIAL_REG_BAUD_LSB
+    mov     al, BAUD_DIV & 0xFF
+    out     dx, al
+    mov     al, BAUD_DIV >> 8
+    mov     dx, COM_PORT + SERIAL_REG_BAUD_MSB
+    out     dx, al
+
+    // Unset DLAB bit.
+    mov     dx, COM_PORT + SERIAL_REG_LINE_CTRL
+    in      al, dx
+    and     al, ~(1 << 7)
+    out     dx, al
+
+    // Set 8bits per characters, 1 stop bit and no parity.
+    //  - Char width is in the 2 LSbits of the line control register. Should
+    //  both be 1.
+    //  - Stop bit is bit 2, should be 0.
+    //  - Parity is disabled by setting the bit 3 to 0.
+    mov     dx, COM_PORT + SERIAL_REG_LINE_CTRL
+    in      al, dx
+    or      al, 3
+    and     al, ~((1 << 2) | (1 << 3))
+    out     dx, al
+    
+    leave
+    ret
+
+// ============================================================================= 
+// Output a character through COM0, 32-bit mode version.
+// @param (DWORD) The character to be printed.
+// ============================================================================= 
+ASM_FUNC_DEF32(putc_serial32):
+    push    ebp
+    mov     ebp, esp
+
+    // Wait for the transmission buffer to be empty. This is indicated by the
+    // bit 6 of the line status register.
+    mov     dx, COM_PORT + SERIAL_REG_LINE_STAT
+0:
+    in      al, dx
+    test    al, (1 << 6)
+    jz      0b
+
+    // Transmission buffer free. Send the char. 
+    mov     dx, COM_PORT + SERIAL_REG_DATA
+    mov     al, [ebp + 0x8]
+    out     dx, al
+
+    cmp     BYTE PTR [ebp + 0x8], '\n'
+    jne     0f
+    // New lines in serial output should be followed by a carriage return. Do
+    // this here, hidden from the caller.
+    push    '\r'
+    call    putc_serial32
+    add     esp, 4
+0:
+
+    leave
+    ret
+
+// ============================================================================= 
+// Output a character through COM0, 64-bit mode version.
+// @param (DWORD) The character to be printed.
+// ============================================================================= 
+ASM_FUNC_DEF64(putc_serial64):
+    push    rbp
+    mov     rbp, rsp
+
+    // Wait for the transmission buffer to be empty. This is indicated by the
+    // bit 6 of the line status register.
+    mov     dx, COM_PORT + SERIAL_REG_LINE_STAT
+0:
+    in      al, dx
+    test    al, (1 << 6)
+    jz      0b
+
+    // Transmission buffer free. Send the char. 
+    mov     dx, COM_PORT + SERIAL_REG_DATA
+    mov     al, dil
+    out     dx, al
+
+    cmp     dil, '\n'
+    jne     0f
+    // New lines in serial output should be followed by a carriage return. Do
+    // this here, hidden from the caller.
+    mov     dil, '\r'
+    call    putc_serial64
+0:
+
+    leave
+    ret

--- a/bootstrap/syscall.S
+++ b/bootstrap/syscall.S
@@ -42,6 +42,7 @@ SYSCALL_TABLE:
 .quad   0x0
 .quad   0x0
 .quad   do_get_tsc_freq
+.quad   do_log_serial
 SYSCALL_TABLE_END:
 
 // =============================================================================
@@ -135,4 +136,35 @@ ASM_FUNC_DEF64(syscall_callback):
 // =============================================================================
 ASM_FUNC_DEF64(do_get_tsc_freq):
     mov     rax, [TSC_FREQ]
+    ret
+
+// =============================================================================
+// Log a message to the serial console. This is the implementation of the
+// SYSNR_LOG_SERIAL syscall.
+// @param (RDI): The NUL-terminated string to be printed.
+// =============================================================================
+ASM_FUNC_DEF64(do_log_serial):
+    push    rbp
+    mov     rbp, rsp
+    push    rbx
+
+    // RBX = Pointer to next char to print.
+    mov     rbx, rdi
+
+    // Iterate over each char of the string and use putc_serial64 to print it
+    // out.
+    jmp     ._do_log_serial_loop_cond
+._do_log_serial_loop:
+    movzx   rdi, al
+    call    putc_serial64
+    
+    inc     rbx
+._do_log_serial_loop_cond:
+    // AL = next char to print.
+    mov     al, [rbx]
+    test    al, al
+    jnz     ._do_log_serial_loop
+
+    pop     rbx
+    leave
     ret

--- a/bootstrap/syscall.S
+++ b/bootstrap/syscall.S
@@ -41,6 +41,7 @@
 SYSCALL_TABLE:
 .quad   0x0
 .quad   0x0
+.quad   do_get_tsc_freq
 SYSCALL_TABLE_END:
 
 // =============================================================================
@@ -125,4 +126,13 @@ ASM_FUNC_DEF64(syscall_callback):
 
     // Return to interrupted context.
     leave
+    ret
+
+// =============================================================================
+// Get the TSC's frequency in Hz. This is the implementaion of the
+// SYSNR_GET_TSC_FREQ syscall.
+// @return (RAX): The TSC's frequency.
+// =============================================================================
+ASM_FUNC_DEF64(do_get_tsc_freq):
+    mov     rax, [TSC_FREQ]
     ret

--- a/bootstrap/syscall.S
+++ b/bootstrap/syscall.S
@@ -43,6 +43,7 @@ SYSCALL_TABLE:
 .quad   0x0
 .quad   do_get_tsc_freq
 .quad   do_log_serial
+.quad   do_sbrk
 SYSCALL_TABLE_END:
 
 // =============================================================================
@@ -165,6 +166,63 @@ ASM_FUNC_DEF64(do_log_serial):
     test    al, al
     jnz     ._do_log_serial_loop
 
+    pop     rbx
+    leave
+    ret
+
+// =============================================================================
+// Increment or decrement the program break of the current process.
+// @param (RDI): Increment in bytes. This can be negative to de-allocate heap
+// memory. A value of 0 will return the current program break.
+// @return (RAX): The new value of the program break.
+// Note: The actual size being added or removed to/from the program break might
+// be different than the argument passed for alignment purposes.
+// =============================================================================
+ASM_FUNC_DEF64(do_sbrk):
+    push    rbp
+    mov     rbp, rsp
+    push    rbx
+
+    cmp     rdi, 0x0
+    jl      ._do_sbrk_dealloc
+._do_sbrk_alloc:
+    // Allocation is the hard case since we need to allocate physical RAM and
+    // map it to virtual address space.
+    // To make things easier, we are allocating by multiple of PAGE_SIZE.
+    // RDX = Number of pages to allocate.
+    mov     rdx, rdi
+    shr     rdx, 12
+    test    rdi, (PAGE_SIZE - 1)
+    setnz   al
+    movzx   rax, al
+    add     rdx, rax
+
+    push    rdx
+    // Allocate virtual memory starting at the current program break.
+    mov     rdi, [PROGRAM_BREAK]
+    mov     rsi, (MAP_USER | MAP_WRITE)
+    // RDX already contains the number of pages to allocate.
+    call    alloc_virt
+    pop     rdx
+
+    // Compute the new program break.
+    shl     rdx, 12
+    add     [PROGRAM_BREAK], rdx
+    mov     rax, [PROGRAM_BREAK]
+    jmp     ._do_sbrk_end
+._do_sbrk_dealloc:
+    // Heap de-allocation is not yet implemented. For now we simply do nothing.
+    mov     rax, [PROGRAM_BREAK]
+._do_sbrk_end:
+    // RAX must be set to return value before jumping to here.
+    // Make sure the new PROGRAM_BREAK is page aligned.
+    test    QWORD PTR [PROGRAM_BREAK], (PAGE_SIZE - 1)
+    jz      0f
+    PANIC64("do_sbrk: New program break is not page aligned")
+0:
+    push    rax
+    DEBUG64("do_sbrk: New program break @ %q\n")
+    pop     rax
     pop     rbx
     leave
     ret

--- a/bootstrap/syscall.S
+++ b/bootstrap/syscall.S
@@ -1,0 +1,128 @@
+// Syscall related routines.
+// Syscalls in Krayte are done through software interrupts for now. In the
+// future we might add support for the SYSCALL/SYSENTER instructions, but for
+// now we try to keep things simple (interrupts are well tested) and portable
+// (at least for syscalls).
+//
+// Syscalls through software interrupts use the following conventions:
+//  - Vector is INTERRUPT_SYSCALL_VEC.
+//  - RAX contains the syscall number.
+//  - Parameters of the syscall are passed through registers in the following
+//  order:
+//      1. RDI
+//      2. RSI
+//      3. RDX
+//      4. RCX
+//      5. R8
+//      6. R9
+//  - For now a syscall can only take up to 6 parameters. Passing extra
+//  parameters through the stack can be added later. There is no use cases for
+//  more than 6 parameters for now.
+//  - RAX will contains the return value of the syscall.
+// Syscall numbers are defined in consts.h
+
+#include <asm_macros.h>
+#include <consts.h>
+
+.intel_syntax   noprefix
+
+.section .data
+// The SYSCALL_TABLE is a simple array mapping a syscall number to its handler.
+// Each entry in the table is a 64-bit pointer to a handler. Entries are indexed
+// by syscall number, that is entry i correspond to syscall number i and
+// SYSCALL_TABLE + i * 8 contains the pointer to the handler for syscall number
+// i.
+// 0x0 entries indicate non-implemented syscalls.
+// Note: Handlers should be written like regular routines, that is using the
+// custom 64-bit SYSV ABI, without expecting arguments on the stack (limit of 6
+// arguments).
+// Note2: The first 2 entries of the syscall table are reserved for testing.
+.global SYSCALL_TABLE
+SYSCALL_TABLE:
+.quad   0x0
+.quad   0x0
+SYSCALL_TABLE_END:
+
+// =============================================================================
+// Initialize syscall handling.
+// =============================================================================
+ASM_FUNC_DEF64(init_syscall):
+    push    rbp
+    mov     rbp, rsp
+    
+    // The only thing needed at initialization time is to register the callback
+    // for INTERRUPT_SYSCALL_VEC.
+    mov     rdi, INTERRUPT_SYSCALL_VEC
+    lea     rsi, [syscall_callback]
+    call    set_interrupt_callback
+
+    leave
+    ret
+
+// =============================================================================
+// Revert a call to init_syscall. This routine must only be used in tests. The
+// rationale is that syscall tests might expect the syscall subsystem to be
+// initialized to work properly, but init_syscall cannot be called before
+// running the tests as it would conflict with interrupt tests registering
+// callbacks for every vectors.
+// =============================================================================
+ASM_FUNC_DEF64(reset_syscall):
+    // For now we simply need to remove the interrupt callback used for
+    // syscalls.
+    mov     rdi, INTERRUPT_SYSCALL_VEC
+    call    del_interrupt_callback
+    ret
+
+// =============================================================================
+// Callback for a syscall through a software interrupt INTERRUPT_SYSCALL_VEC.
+// @param (RDI): Pointer to the interrupt frame.
+// =============================================================================
+ASM_FUNC_DEF64(syscall_callback):
+    push    rbp
+    mov     rbp, rsp
+
+    // Check that the syscall number is not out of bounds.
+    // RAX = Requested syscall number.
+    mov     rax, [rdi + INT_FRAME_SAVED_RAX_OFF]
+    // RCX = Number of entries in SYSCALL_TABLE.
+    lea     rcx, [SYSCALL_TABLE_END - SYSCALL_TABLE]
+    shr     rcx, 3
+
+    cmp     rax, rcx
+    jb      0f
+    // Syscall number is out of bounds. This usually indicates something went
+    // terribly wrong in the application. PANIC.
+    PANIC64("syscall_callback: Syscall number out of bounds")
+0:
+
+    // Get the handler's address.
+    lea     rcx, [SYSCALL_TABLE]
+    // RAX = handler's address.
+    mov     rax, [rcx + rax * 8]
+
+    // The handler's address may be 0x0, indicating that the syscall is not
+    // (yet) implemented. In this case we should panic.
+    test    rax, rax
+    jnz     0f
+    PANIC64("syscall_callback: Syscall number not implemented")
+0:
+
+    // Unpack the arguments for the handler.
+    mov     rsi, [rdi + INT_FRAME_SAVED_RSI_OFF]
+    mov     rdx, [rdi + INT_FRAME_SAVED_RDX_OFF]
+    mov     rcx, [rdi + INT_FRAME_SAVED_RCX_OFF]
+    mov     r8,  [rdi + INT_FRAME_SAVED_R8_OFF]
+    mov     r9,  [rdi + INT_FRAME_SAVED_R9_OFF]
+    push    rdi
+    mov     rdi, [rdi + INT_FRAME_SAVED_RDI_OFF]
+
+    // Call the handler.
+    call    rax
+
+    pop     rdi
+    // Set the saved RAX to the return value of the handler.
+    mov     [rdi + INT_FRAME_SAVED_RAX_OFF], rax
+
+    // Return to interrupted context.
+    leave
+    ret

--- a/bootstrap/tests/frame_alloc.S
+++ b/bootstrap/tests/frame_alloc.S
@@ -112,3 +112,153 @@ ASM_FUNC_DEF32(allocate_frame32_test):
     leave
     ret
 REGISTER_TEST(allocate_frame32_test)
+
+.section .data
+n_node0:
+.quad   n_node1
+.quad   0xC000
+.quad   1
+n_node1:
+.quad   n_node2
+.quad   0xDEAD000
+.quad   2
+n_node2:
+.quad   0x0
+.quad   0xFFFFF000
+.quad   64
+
+
+// =============================================================================
+// Simple test for the allocate_n_frames32 routine and its edge cases.
+// =============================================================================
+ASM_FUNC_DEF32(allocate_n_frames32_test):
+    push    ebp
+    mov     ebp, esp
+
+    // Save the actual value of FRAME_ALLOC_HEAD.
+    push    [FRAME_ALLOC_HEAD + 4]
+    push    [FRAME_ALLOC_HEAD]
+
+    // Set the FRAME_ALLOC_HEAD to the fake linked-list.
+    lea     eax, [n_node0]
+    mov     DWORD PTR [FRAME_ALLOC_HEAD + 4], 0x0
+    mov     [FRAME_ALLOC_HEAD], eax
+
+    // Test case 1: Allocate 2 frames. Expected ret = 0xDEAD000. n_node0 still
+    // has size = 1 and its next is n_node2.
+    push    2
+    call    allocate_n_frames32
+    add     esp, 4
+    cmp     eax, 0xDEAD000
+    jne     .n_fail
+
+    lea     eax, [n_node0]
+    cmp     DWORD PTR [eax + NODE_ADDR_OFF + 4], 0x0
+    jne     .n_fail
+    cmp     DWORD PTR [eax + NODE_ADDR_OFF], 0xC000
+    jne     .n_fail
+
+    cmp     DWORD PTR [eax + NODE_SIZE_OFF + 4], 0x0
+    jne     .n_fail
+    cmp     DWORD PTR [eax + NODE_SIZE_OFF], 0x1
+    jne     .n_fail
+
+    cmp     DWORD PTR [eax + NODE_NEXT_OFF + 4], 0x0
+    jne     .n_fail
+    lea     ecx, [n_node2]
+    cmp     DWORD PTR [eax + NODE_NEXT_OFF], ecx
+    jne     .n_fail
+
+    cmp     DWORD PTR [FRAME_ALLOC_HEAD + 4], 0x0
+    jne     .n_fail
+    cmp     [FRAME_ALLOC_HEAD], eax
+    jne     .n_fail
+
+    // Test case 2: Allocate 1 frame. Expected ret = 0xC000, n_node2 is the only
+    // remaining node.
+    push    1
+    call    allocate_n_frames32
+    add     esp, 4
+    cmp     eax, 0xC000
+    jne     .n_fail
+
+    lea     eax, [n_node2]
+    cmp     DWORD PTR [eax + NODE_ADDR_OFF + 4], 0x0
+    jne     .n_fail
+    cmp     DWORD PTR [eax + NODE_ADDR_OFF], 0xFFFFF000
+    jne     .n_fail
+
+    cmp     DWORD PTR [eax + NODE_SIZE_OFF + 4], 0x0
+    jne     .n_fail
+    cmp     DWORD PTR [eax + NODE_SIZE_OFF], 64
+    jne     .n_fail
+
+    cmp     DWORD PTR [eax + NODE_NEXT_OFF + 4], 0x0
+    jne     .n_fail
+    cmp     DWORD PTR [eax + NODE_NEXT_OFF], 0x0
+    jne     .n_fail
+
+    cmp     DWORD PTR [FRAME_ALLOC_HEAD + 4], 0x0
+    jne     .n_fail
+    cmp     [FRAME_ALLOC_HEAD], eax
+    jne     .n_fail
+
+    // Test case 3: Allocate 2 frames. This is not possible with n_node2 because
+    // it would go over 4GiB.
+    push    2
+    call    allocate_n_frames32
+    add     esp, 4
+    cmp     eax, NO_FRAME
+    jne     .n_fail
+
+    // Test case 4: Allocate 1 frame. This is possible in n_node2. Expected ret
+    // = 0xFFFFF000. n_node2 should have its base address above 4GiB.
+    push    1
+    call    allocate_n_frames32
+    add     esp, 4
+    cmp     eax, 0xFFFFF000
+    jne     .n_fail
+
+    lea     eax, [n_node2]
+    cmp     DWORD PTR [eax + NODE_ADDR_OFF + 4], 0x1
+    jne     .n_fail
+    cmp     DWORD PTR [eax + NODE_ADDR_OFF], 0x0
+    jne     .n_fail
+
+    cmp     DWORD PTR [eax + NODE_SIZE_OFF + 4], 0x0
+    jne     .n_fail
+    cmp     DWORD PTR [eax + NODE_SIZE_OFF], 63
+    jne     .n_fail
+
+    cmp     DWORD PTR [eax + NODE_NEXT_OFF + 4], 0x0
+    jne     .n_fail
+    cmp     DWORD PTR [eax + NODE_NEXT_OFF], 0x0
+    jne     .n_fail
+
+    cmp     DWORD PTR [FRAME_ALLOC_HEAD + 4], 0x0
+    jne     .n_fail
+    cmp     [FRAME_ALLOC_HEAD], eax
+    jne     .n_fail
+
+    // Test case 5: Allocate 1 frame. Since n_node2 is the only group left and
+    // starts above 4GiB the allocation should fail.
+    push    1
+    call    allocate_n_frames32
+    add     esp, 4
+    cmp     eax, NO_FRAME
+    jne     .n_fail
+
+    // Success.
+    mov     eax, 1
+    jmp     .n_out
+
+.n_fail:
+    xor     eax, eax
+.n_out:
+
+    // Restore FRAME_ALLOC_HEAD.
+    pop     [FRAME_ALLOC_HEAD]
+    pop     [FRAME_ALLOC_HEAD + 4]
+    leave
+    ret
+REGISTER_TEST(allocate_n_frames32_test)

--- a/bootstrap/tests/interrupt.S
+++ b/bootstrap/tests/interrupt.S
@@ -1,0 +1,612 @@
+// Tests for interrupts.
+
+#include <asm_macros.h>
+#include <consts.h>
+#include <test_macros.h>
+
+.intel_syntax   noprefix
+
+.section .data
+// Those values are used by the _set_registers_value helper to set the value of
+// all general purpose 64-bit registers.
+specific_val_rax: .quad 0xAAAAAAAAAAAAAAAA
+specific_val_rbx: .quad 0xBBBBBBBBBBBBBBBB
+specific_val_rcx: .quad 0xCCCCCCCCCCCCCCCC
+specific_val_rdx: .quad 0xDDDDDDDDDDDDDDDD
+specific_val_rbp: .quad 0xB0B0B0B0B0B0B0B0
+specific_val_rdi: .quad 0xD1D1D1D1D1D1D1D1
+specific_val_rsi: .quad 0x5151515151515151
+specific_val_r8:  .quad 0x8888888888888888
+specific_val_r9:  .quad 0x9999999999999999
+specific_val_r10: .quad 0x1010101010101010
+specific_val_r11: .quad 0x1111111111111111
+specific_val_r12: .quad 0x1212121212121212
+specific_val_r13: .quad 0x1313131313131313
+specific_val_r14: .quad 0x1414141414141414
+specific_val_r15: .quad 0x1515151515151515
+
+// ============================================================================= 
+// Set all general purpose registers values to some specific values.
+// Note: RSP is left untouched.
+// ============================================================================= 
+ASM_FUNC_DEF64(_set_registers_value):
+    mov     rax, QWORD PTR [specific_val_rax]
+    mov     rbx, QWORD PTR [specific_val_rbx]
+    mov     rcx, QWORD PTR [specific_val_rcx]
+    mov     rdx, QWORD PTR [specific_val_rdx]
+    mov     rbp, QWORD PTR [specific_val_rbp]
+    mov     rdi, QWORD PTR [specific_val_rdi]
+    mov     rsi, QWORD PTR [specific_val_rsi]
+    mov     r8,  QWORD PTR [specific_val_r8]
+    mov     r9,  QWORD PTR [specific_val_r9]
+    mov     r10, QWORD PTR [specific_val_r10]
+    mov     r11, QWORD PTR [specific_val_r11]
+    mov     r12, QWORD PTR [specific_val_r12]
+    mov     r13, QWORD PTR [specific_val_r13]
+    mov     r14, QWORD PTR [specific_val_r14]
+    mov     r15, QWORD PTR [specific_val_r15]
+    ret
+
+// ============================================================================= 
+// Check that all general purpose registers (except RSP) have the same values as
+// set by _set_registers_value.
+// @return (RAX): 1 if values match, 0 otherwise.
+// ============================================================================= 
+ASM_FUNC_DEF64(_check_registers_value):
+    cmp     rax, QWORD PTR [specific_val_rax]
+    jne     ._check_registers_value_fail
+    cmp     rbx, QWORD PTR [specific_val_rbx]
+    jne     ._check_registers_value_fail
+    cmp     rcx, QWORD PTR [specific_val_rcx]
+    jne     ._check_registers_value_fail
+    cmp     rdx, QWORD PTR [specific_val_rdx]
+    jne     ._check_registers_value_fail
+    cmp     rbp, QWORD PTR [specific_val_rbp]
+    jne     ._check_registers_value_fail
+    cmp     rdi, QWORD PTR [specific_val_rdi]
+    jne     ._check_registers_value_fail
+    cmp     rsi, QWORD PTR [specific_val_rsi]
+    jne     ._check_registers_value_fail
+    cmp     r8,  QWORD PTR [specific_val_r8]
+    jne     ._check_registers_value_fail
+    cmp     r9,  QWORD PTR [specific_val_r9]
+    jne     ._check_registers_value_fail
+    cmp     r10, QWORD PTR [specific_val_r10]
+    jne     ._check_registers_value_fail
+    cmp     r11, QWORD PTR [specific_val_r11]
+    jne     ._check_registers_value_fail
+    cmp     r12, QWORD PTR [specific_val_r12]
+    jne     ._check_registers_value_fail
+    cmp     r13, QWORD PTR [specific_val_r13]
+    jne     ._check_registers_value_fail
+    cmp     r14, QWORD PTR [specific_val_r14]
+    jne     ._check_registers_value_fail
+    cmp     r15, QWORD PTR [specific_val_r15]
+    jne     ._check_registers_value_fail
+    // All values match.
+    mov     rax, 1
+    ret
+._check_registers_value_fail:
+    // No match.
+    xor     rax, rax
+    ret
+
+// #############################################################################
+// ============================================================================= 
+// Test that a registered callback is called upon a given interrupt.
+// This is tested for _all_ interrupt vectors of the IDT.
+// The test works as follows: For each vector V:
+//  1. Register callback for V to use interrupt_callback_test_callback.
+//  2. Reset interrupt_callback_test_callback_called to 0x0.
+//  3. Raise a software interrupt with vector V.
+//  4. Delete the callback for V.
+//  5. Check that interrupt_callback_test_callback_called  is 0x1. This was set
+//  by interrupt_callback_test_callback.
+// ============================================================================= 
+ASM_FUNC_DEF64(interrupt_callback_test):
+    push    rbp
+    mov     rbp, rsp
+    push    rbx
+
+    // BL = Vector of next interrupt.
+    mov     bl, 0x0
+    jmp     interrupt_callback_test_loop_cond
+interrupt_callback_test_loop:
+    // Register the callback.
+    movzx   rdi, bl
+    lea     rsi, [interrupt_callback_test_callback]
+    call    set_interrupt_callback
+
+    // Reset interrupt_callback_test_callback_called.
+    mov     BYTE PTR [interrupt_callback_test_callback_called], 0x0
+
+    // Raise the interrupt. We use some self-modifying code in order to have a
+    // "generic" INT instruction. This is ok because bootstrap code is mapped as
+    // writable (for now).
+    mov     BYTE PTR [interrupt_callback_test_int_vec], bl
+
+    // 0xCD is the opcode for the INT imm8 instruction.
+    .byte   0xCD
+interrupt_callback_test_int_vec:
+    .byte   0x0
+
+    // Delete the callback.
+    movzx   rdi, bl
+    call    del_interrupt_callback
+
+    // Check that the callback was called.
+    movzx   rax, BYTE PTR [interrupt_callback_test_callback_called]
+    test    rax, rax
+    jz      interrupt_callback_test_failed
+
+    // Next iteration.
+    inc     bl
+interrupt_callback_test_loop_cond:
+    cmp     bl, INTERRUPT_IDT_SIZE
+    jb      interrupt_callback_test_loop
+
+    // Success.
+    mov     rax, 1
+    jmp     interrupt_callback_test_end
+interrupt_callback_test_failed:
+    // Failure.
+    xor     rax, rax
+
+interrupt_callback_test_end:
+    pop     rbx
+    leave
+    ret
+REGISTER_TEST64(interrupt_callback_test)
+
+.section .data
+// Indicate if the interrupt_callback_test_callback was called.
+interrupt_callback_test_callback_called:
+.byte   0x0
+
+// ============================================================================= 
+// The callback used for each vector in the interrupt_callback_test routine.
+// This routine will set interrupt_callback_test_callback_called to 1.
+// ============================================================================= 
+ASM_FUNC_DEF64(interrupt_callback_test_callback):
+    mov     BYTE PTR [interrupt_callback_test_callback_called], 1
+    ret
+
+// #############################################################################
+// ============================================================================= 
+// Test checking that the interrupt frame pointer passed to an interrupt
+// callback points to correct information, that is:
+//  - Saved register values are correct.
+//  - Vector is correct.
+//  - Hardware interrupt frame is correct.
+// The test works as follows, for all vector V.
+//  1. Register interrupt callback for V and reset success flag.
+//  2. Set registers to some values.
+//  3. Raise software interrupt vector V.
+//  4. In callback:
+//      4.1. Check the values of the saved registers of the interrupt frame.
+//      4.2. Check the value of the vector in the interrupt frame.
+//      4.3. Check the hardware interrupt frame.
+//      4.4. If all the above successful, set the success flag.
+//  5. (After returning from INT) Check the success flag.
+// ============================================================================= 
+ASM_FUNC_DEF64(interrupt_callback_int_frame_test):
+    push    rbp
+    mov     rbp, rsp
+    // Save all callee-saved registers, we will clobber them as part of the
+    // test.
+    push    rbx
+    push    r12
+    push    r13
+    push    r14
+    push    r15
+
+    // BL = Next vector to raise.
+    xor     rbx, rbx
+._interrupt_callback_int_frame_test_loop:
+    // Register callback.
+    movzx   rdi, bl
+    lea     rsi, [interrupt_callback_int_frame_test_callback]
+    call    set_interrupt_callback
+
+    // Reset flag.
+    mov     BYTE PTR [interrupt_callback_int_frame_test_success_flag], 0x0
+
+    // Set the vector for the interrupt. We need to do this before overwritting
+    // RBX.
+    mov     BYTE PTR [._interrupt_callback_int_frame_test_vec], bl
+
+    // We need to save RBP and RBX since they will be overwritten by
+    // _set_registers_value.
+    push    rbp
+    push    rbx
+
+    // Set all registers to some values.
+    call    _set_registers_value
+
+    // Set the expected RFLAGS and RSP for the callback.
+    pushfq
+    pop     [interrupt_callback_int_frame_test_expected_rflags]
+    mov     [interrupt_callback_int_frame_test_expected_rsp], rsp
+    // Raise the interrupt.
+    .byte   0xCD
+._interrupt_callback_int_frame_test_vec:
+    .byte   0x0
+    // Software interrupts generate "traps" hence the expected RIP is the
+    // instruction following the INT. This is what the callback expects for the
+    // saved value of RIP in the interrupt frame.
+interrupt_callback_int_frame_test_expected_rip:
+
+    pop     rbx
+    pop     rbp
+
+    // Remove the callback.
+    movzx   rdi, bl
+    call    del_interrupt_callback
+
+    // Check the success flag.
+    movzx   rax, BYTE PTR [interrupt_callback_int_frame_test_success_flag]
+    test    rax, rax
+    jz      ._interrupt_callback_int_frame_test_fail
+
+    // Try with next vector.
+    inc     bl
+._interrupt_callback_int_frame_test_loop_cond:
+    cmp     bl, INTERRUPT_IDT_SIZE
+    jb      ._interrupt_callback_int_frame_test_loop
+
+    // Success.
+    mov     rax, 1
+    jmp     ._interrupt_callback_int_frame_test_end
+._interrupt_callback_int_frame_test_fail:
+    xor     rax, rax
+._interrupt_callback_int_frame_test_end:
+    pop     r15
+    pop     r14
+    pop     r13
+    pop     r12
+    pop     rbx
+    leave
+    ret
+REGISTER_TEST64(interrupt_callback_int_frame_test)
+
+.section .data
+// The success flags. This is used by the callback to indicate success.
+interrupt_callback_int_frame_test_success_flag:
+.byte   0x0
+// The expected value for RFLAGS in the interrupt frame.
+interrupt_callback_int_frame_test_expected_rflags:
+.quad   0x0
+// The expected value for RSP in the interrupt frame.
+interrupt_callback_int_frame_test_expected_rsp:
+.quad   0x0
+
+
+// ============================================================================= 
+// Callback for an interrupt generated during
+// interrupt_callback_int_frame_test_callback. This routine will check the
+// interrupt frame passed as argument and expects the following:
+//  - Saved values of registers correspond to values set by
+//  _set_registers_value.
+//  - Vector matches ._interrupt_callback_int_frame_test_vec.
+//  - Info pushed by the hardware is consistent with what we expects.
+// If everything is in order, this routine will set
+// interrupt_callback_int_frame_test_success_flag to 0x1. Otherwise it sets it
+// to 0x0.
+// @param (RDI): The interrupt frame.
+// ============================================================================= 
+ASM_FUNC_DEF64(interrupt_callback_int_frame_test_callback):
+    push    rbp
+    mov     rbp, rsp
+
+    // Check the saved values of the registers.
+    // TODO: Once again we are not supporting segment registers here.
+    mov     rax, [specific_val_rax]
+    cmp     [rdi + INT_FRAME_SAVED_RAX_OFF], rax
+    jne     ._interrupt_callback_int_frame_test_callback_fail
+    mov     rax, [specific_val_rbx]
+    cmp     [rdi + INT_FRAME_SAVED_RBX_OFF], rax
+    jne     ._interrupt_callback_int_frame_test_callback_fail
+    mov     rax, [specific_val_rcx]
+    cmp     [rdi + INT_FRAME_SAVED_RCX_OFF], rax
+    jne     ._interrupt_callback_int_frame_test_callback_fail
+    mov     rax, [specific_val_rdx]
+    cmp     [rdi + INT_FRAME_SAVED_RDX_OFF], rax
+    jne     ._interrupt_callback_int_frame_test_callback_fail
+    mov     rax, [specific_val_rbp]
+    cmp     [rdi + INT_FRAME_SAVED_RBP_OFF], rax
+    jne     ._interrupt_callback_int_frame_test_callback_fail
+    mov     rax, [specific_val_rsi]
+    cmp     [rdi + INT_FRAME_SAVED_RSI_OFF], rax
+    jne     ._interrupt_callback_int_frame_test_callback_fail
+    mov     rax, [specific_val_rdi]
+    cmp     [rdi + INT_FRAME_SAVED_RDI_OFF], rax
+    jne     ._interrupt_callback_int_frame_test_callback_fail
+    mov     rax, [specific_val_r8]
+    cmp     [rdi + INT_FRAME_SAVED_R8_OFF], rax
+    jne     ._interrupt_callback_int_frame_test_callback_fail
+    mov     rax, [specific_val_r9]
+    cmp     [rdi + INT_FRAME_SAVED_R9_OFF], rax
+    jne     ._interrupt_callback_int_frame_test_callback_fail
+    mov     rax, [specific_val_r10]
+    cmp     [rdi + INT_FRAME_SAVED_R10_OFF], rax
+    jne     ._interrupt_callback_int_frame_test_callback_fail
+    mov     rax, [specific_val_r11]
+    cmp     [rdi + INT_FRAME_SAVED_R11_OFF], rax
+    jne     ._interrupt_callback_int_frame_test_callback_fail
+    mov     rax, [specific_val_r12]
+    cmp     [rdi + INT_FRAME_SAVED_R12_OFF], rax
+    jne     ._interrupt_callback_int_frame_test_callback_fail
+    mov     rax, [specific_val_r13]
+    cmp     [rdi + INT_FRAME_SAVED_R13_OFF], rax
+    jne     ._interrupt_callback_int_frame_test_callback_fail
+    mov     rax, [specific_val_r14]
+    cmp     [rdi + INT_FRAME_SAVED_R14_OFF], rax
+    jne     ._interrupt_callback_int_frame_test_callback_fail
+    mov     rax, [specific_val_r15]
+    cmp     [rdi + INT_FRAME_SAVED_R15_OFF], rax
+    jne     ._interrupt_callback_int_frame_test_callback_fail
+
+    // Check the vector.
+    movzx   rax, BYTE PTR [._interrupt_callback_int_frame_test_vec]
+    cmp     rax, [rdi + INT_FRAME_VECTOR_OFF]
+    jne     ._interrupt_callback_int_frame_test_callback_fail
+
+    // Check the hardware interrupt frame. 
+    // FIXME: Hardcoded 64-bit data segment.
+    cmp     QWORD PTR [rdi + INT_FRAME_SS_OFF], 0x28
+    jne     ._interrupt_callback_int_frame_test_callback_fail
+    mov     rax, [interrupt_callback_int_frame_test_expected_rsp]
+    cmp     [rdi + INT_FRAME_RSP_OFF], rax
+    jne     ._interrupt_callback_int_frame_test_callback_fail
+    mov     rax, [interrupt_callback_int_frame_test_expected_rflags]
+    cmp     [rdi + INT_FRAME_RFLAGS_OFF], rax
+    jne     ._interrupt_callback_int_frame_test_callback_fail
+    // FIXME: Hardcoded 64-bit code segment.
+    cmp     QWORD PTR [rdi + INT_FRAME_CS_OFF], 0x30
+    jne     ._interrupt_callback_int_frame_test_callback_fail
+    // Software interrupts do not add error messages, hence we expect the dummy
+    // one added by generic_handler.
+    mov     rax, 0xC0DEC0DEC0DEC0DE
+    cmp     QWORD PTR [rdi + INT_FRAME_ERROR_CODE_OFF], rax
+    jne     ._interrupt_callback_int_frame_test_callback_fail
+    cmp     QWORD PTR [rdi + INT_FRAME_RIP_OFF], OFFSET FLAT : \
+            interrupt_callback_int_frame_test_expected_rip
+    jne     ._interrupt_callback_int_frame_test_callback_fail
+
+    // Success, set the flags to true.
+    mov     BYTE PTR [interrupt_callback_int_frame_test_success_flag], 0x1
+    leave
+    ret
+._interrupt_callback_int_frame_test_callback_fail:
+    // Failure, make sure the success flag is false.
+    mov     BYTE PTR [interrupt_callback_int_frame_test_success_flag], 0x0
+    leave
+    ret
+
+// #############################################################################
+// ============================================================================= 
+// Tests that general purpose registers are correctly restored by the generic
+// interrupt handler before returning to the interrupted context.
+// This is tested in the following scenario:
+//  1. All registers are set to specific values.
+//  2. A software interrupt is raised. The callback clobbers all caller-saved
+//  registers.
+//  3. After returning from the interrupt the values of each register is checked
+//  against its respective expected value.
+// Unfortunately this test has a big limitation: The callback can only clobber
+// caller-saved registers, otherwise it could lead to errors in the generic
+// interrupt handler.
+// ============================================================================= 
+ASM_FUNC_DEF64(interrupt_registers_save_test):
+    push    rbp
+    mov     rbp, rsp
+    // Save all callee-saved registers.
+    push    rbx
+    push    r12
+    push    r13
+    push    r14
+    push    r15
+    push    rbp
+
+    // 1. Register callback. For this test we use interrupt vector = 0x0.
+    xor     rdi, rdi
+    lea     rsi, [interrupt_registers_save_test_callback]
+    call    set_interrupt_callback
+
+    // 2. Set all registers to distincts values. We cannot set the stack pointer
+    // to an arbitrary value. This would produce a page fault.
+    call    _set_registers_value
+    // TODO: We should probably try to set the segment registers to different
+    // values. However for now saving and restoring of seg registers is not
+    // supported. This is because the application code won't touch them. In the
+    // future we should add this feature, for completness ...
+
+    // 3. Raise the interrupt.
+    int     0x0
+
+    // 4. Check the values of the registers.
+    // RAX = Result of comparison = result of the test.
+    call    _check_registers_value
+
+    // Remove interrupt callback.
+    push    rax
+    xor     rdi, rdi
+    call    del_interrupt_callback
+    pop     rax
+
+    // Restore callee-saved regs.
+    pop     rbp
+    pop     r15
+    pop     r14
+    pop     r13
+    pop     r12
+    pop     rbx
+    leave
+    ret
+REGISTER_TEST64(interrupt_registers_save_test)
+
+// ============================================================================= 
+// Callback for the interrupt raised in interrupt_register_save_test. This
+// callback will clobber all caller-saved registers.
+// ============================================================================= 
+ASM_FUNC_DEF64(interrupt_registers_save_test_callback):
+    // Make sure that all caller-saved registers get a different value from what
+    // they had before. This is easily done by NOTing them.
+    not     rax
+    not     rcx
+    not     rdx
+    not     rdi
+    not     rsi
+    not     r8
+    not     r9
+    not     r10
+    not     r11
+    ret
+
+
+// #############################################################################
+// ============================================================================= 
+// Test that an interrupt callback can overwrite saved registers and that the
+// writes will be reflected in the interrupted context once it resumes
+// execution. This test works as follows:
+//  1. Set registers to some value.
+//  2. Raise an interrupt vector = V.
+//  3. In the callback for V:
+//      3.1. NOT all saved general purpose registers values.
+//      3.2. Change saved RIP.
+//      3.3. Change saved RFLAGS (Set the carry flag).
+//  4. When returning from the INT, NOT all registers.
+//  5. Check all register values using _check_registers_value. This should be
+//  successful since the NOT in step 4 cancelled the NOT from the callback.
+// Any vector will do, we choose V = 0x0.
+// ============================================================================= 
+ASM_FUNC_DEF64(interrupt_register_overwrite_test):
+    push    rbp
+    mov     rbp, rsp
+    // Save all callee-saved registers.
+    push    rbx
+    push    r12
+    push    r13
+    push    r14
+    push    r15
+    push    rbp
+
+    // 1. Register callback. For this test we use interrupt vector = 0x0.
+    xor     rdi, rdi
+    lea     rsi, [interrupt_register_overwrite_test_callback]
+    call    set_interrupt_callback
+
+    // 2. Set all registers to distincts values. We cannot set the stack pointer
+    // to an arbitrary value. This would produce a page fault.
+    call    _set_registers_value
+    // TODO: Segment registers unchanged.
+
+    mov     [interrupt_register_overwrite_test_expected_rsp], rsp
+    not     QWORD PTR [interrupt_register_overwrite_test_expected_rsp]
+
+    // Unset the Carry Flag so we are sure that if it set after the interrupt
+    // this would have come from the handler.
+    clc
+
+    // 3. Raise the interrupt.
+    int     0x0
+    PANIC64("interrupt_register_overwrite_test: RIP was not changed")
+
+interrupt_register_overwrite_test_exp_rip:
+    // This is what the interrupt callback will change the RIP to.
+
+    // Check the CF in RFLAGS, it should be set.
+    jnc     ._interrupt_register_overwrite_test_fail_fixup_rsp
+
+    // Check RSP against interrupt_register_overwrite_test_expected_rsp.
+    cmp     rsp, [interrupt_register_overwrite_test_expected_rsp]
+    jne     ._interrupt_register_overwrite_test_fail_fixup_rsp
+
+    // Restore all GPs by NOTing them, including the RSP.
+    not     rsp
+    not     rax
+    not     rbx
+    not     rcx
+    not     rdx
+    not     rbp
+    not     rdi
+    not     rsi
+    not     r8
+    not     r9
+    not     r10
+    not     r11
+    not     r12
+    not     r13
+    not     r14
+    not     r15
+
+    // Check the values of the registers. They should match the
+    // _set_registers_value.
+    // RAX = Result of comparison = result of the test.
+    call    _check_registers_value
+
+    jmp     ._interrupt_register_overwrite_test_end
+._interrupt_register_overwrite_test_fail_fixup_rsp:
+    // If we end up here then the RSP is not valid. However we can recover the
+    // previous RSP and exit the test.
+    mov     rsp, [interrupt_register_overwrite_test_expected_rsp]
+    not     rsp
+    // The test is a failure.
+    xor     rax, rax
+
+._interrupt_register_overwrite_test_end:
+
+    // Remove interrupt callback.
+    push    rax
+    xor     rdi, rdi
+    call    del_interrupt_callback
+    pop     rax
+
+    // Restore callee-saved regs.
+    pop     rbp
+    pop     r15
+    pop     r14
+    pop     r13
+    pop     r12
+    pop     rbx
+    leave
+    ret
+REGISTER_TEST64(interrupt_register_overwrite_test)
+
+.section .data
+// The expected value of the RSP after returning from the interrupt.
+interrupt_register_overwrite_test_expected_rsp:
+.quad   0x0
+
+// ============================================================================= 
+// Callback for the interrupt raised in interrupt_register_overwrite_test. This
+// callback will NOT all the saved registers, set the CF in RFLAGS and set the
+// saved RIP to interrupt_register_overwrite_test_exp_rip.
+// @param (RDI): Pointer to the interrupt frame.
+// ============================================================================= 
+ASM_FUNC_DEF64(interrupt_register_overwrite_test_callback):
+    // NOT all GPs, including RSP.
+    not     QWORD PTR [rdi + INT_FRAME_SAVED_RAX_OFF]
+    not     QWORD PTR [rdi + INT_FRAME_SAVED_RBX_OFF]
+    not     QWORD PTR [rdi + INT_FRAME_SAVED_RCX_OFF]
+    not     QWORD PTR [rdi + INT_FRAME_SAVED_RDX_OFF]
+    not     QWORD PTR [rdi + INT_FRAME_SAVED_RBP_OFF]
+    not     QWORD PTR [rdi + INT_FRAME_RSP_OFF]
+    not     QWORD PTR [rdi + INT_FRAME_SAVED_RSI_OFF]
+    not     QWORD PTR [rdi + INT_FRAME_SAVED_RDI_OFF]
+    not     QWORD PTR [rdi + INT_FRAME_SAVED_R8_OFF]
+    not     QWORD PTR [rdi + INT_FRAME_SAVED_R9_OFF]
+    not     QWORD PTR [rdi + INT_FRAME_SAVED_R10_OFF]
+    not     QWORD PTR [rdi + INT_FRAME_SAVED_R11_OFF]
+    not     QWORD PTR [rdi + INT_FRAME_SAVED_R12_OFF]
+    not     QWORD PTR [rdi + INT_FRAME_SAVED_R13_OFF]
+    not     QWORD PTR [rdi + INT_FRAME_SAVED_R14_OFF]
+    not     QWORD PTR [rdi + INT_FRAME_SAVED_R15_OFF]
+
+    // Set the carry flag (bit 1) in RFLAGS.
+    or      QWORD PTR [rdi + INT_FRAME_RFLAGS_OFF], 1 
+
+    // Change the RIP to point after the PANIC.
+    lea     rax, [interrupt_register_overwrite_test_exp_rip]
+    mov     [rdi + INT_FRAME_RIP_OFF], rax
+    ret

--- a/bootstrap/tests/syscall.S
+++ b/bootstrap/tests/syscall.S
@@ -1,0 +1,236 @@
+// Tests for syscall handling.
+
+#include <asm_macros.h>
+#include <consts.h>
+#include <test_macros.h>
+
+.intel_syntax   noprefix
+
+// ============================================================================= 
+// Register a handler for one of the test syscall numbers.
+// @param (RDI): Syscall number (0 or 1).
+// @param (RSI): Handler's address.
+// ============================================================================= 
+ASM_FUNC_DEF64(_set_test_handler):
+    push    rbp
+    mov     rbp, rsp
+
+    cmp     rdi, 1
+    jbe     0f
+    PANIC64("_set_test_handler: Syscall number too high, expected 0 or 1")
+0:
+
+    lea     rax, [SYSCALL_TABLE]
+    mov     [rax + rdi * 8], rsi
+    leave
+    ret 
+
+// ============================================================================= 
+// Test that syscalls are correctly dispatched to the correct handler given the
+// syscall number.
+// ============================================================================= 
+ASM_FUNC_DEF64(syscall_dispatch_test):
+    push    rbp
+    mov     rbp, rsp
+
+    call    init_syscall
+
+    xor     rdi, rdi
+    lea     rsi, [syscall_dispatch_test_handler0]
+    call    _set_test_handler
+
+    mov     rdi, 1
+    lea     rsi, [syscall_dispatch_test_handler1]
+    call    _set_test_handler
+
+    mov     BYTE PTR [syscall_dispatch_test_flag], 0xFF
+    mov     rax, SYSNR_TEST0
+    int     INTERRUPT_SYSCALL_VEC
+
+    cmp     BYTE PTR [syscall_dispatch_test_flag], 0x0
+    jne     ._syscall_dispatch_test_fail
+
+    mov     BYTE PTR [syscall_dispatch_test_flag], 0xFF
+    mov     rax, SYSNR_TEST1
+    int     INTERRUPT_SYSCALL_VEC
+
+    cmp     BYTE PTR [syscall_dispatch_test_flag], 0x1
+    jne     ._syscall_dispatch_test_fail
+
+    // Success.
+    mov     rax, 1
+    jmp     ._syscall_dispatch_test_end
+
+._syscall_dispatch_test_fail:
+    xor     rax, rax
+._syscall_dispatch_test_end:
+    push    rax
+    call    reset_syscall
+    pop     rax
+    leave
+    ret
+REGISTER_TEST64(syscall_dispatch_test)
+
+// ============================================================================= 
+// Test handler for SYSNR_TEST0. This routine will simply set
+// syscall_dispatch_test_flag to 0.
+// ============================================================================= 
+ASM_FUNC_DEF64(syscall_dispatch_test_handler0):
+    mov     BYTE PTR [syscall_dispatch_test_flag], 0x0
+    ret
+
+// ============================================================================= 
+// Test handler for SYSNR_TEST1. This routine will simply set
+// syscall_dispatch_test_flag to 1.
+// ============================================================================= 
+ASM_FUNC_DEF64(syscall_dispatch_test_handler1):
+    mov     BYTE PTR [syscall_dispatch_test_flag], 0x1
+    ret
+
+.section .data
+// Flag for the syscall_dispatch_test. This byte indicate which handler was
+// called last.
+syscall_dispatch_test_flag:
+.byte   0xFF
+
+
+// ============================================================================= 
+// Test that parameters are correctly passed to a syscall handler.
+// This test works as follows:
+//  1. The test routine set its parameter registers to some specific values.
+//  2. Call SYSNR_TEST0.
+//  3. The handler for SYSNR_TEST0 checks the value of the param registers
+//  against the expected ones.
+//  4. If the values are correct, it sets the flag to 1.
+// ============================================================================= 
+ASM_FUNC_DEF64(syscall_param_unpack_test):
+    push    rbp
+    mov     rbp, rsp
+
+    call    init_syscall
+    
+    // Set handler for SYSNR_TEST0.
+    mov     rdi, SYSNR_TEST0
+    lea     rsi, [syscall_param_unpack_test_handler]
+    call    _set_test_handler
+
+    // Reset flag.
+    mov     BYTE PTR [syscall_param_unpack_test_flag], 0x0
+
+    // Set the param registers.
+    mov     rdi, 0xD1D1D1D1D1D1D1D1
+    mov     rsi, 0x5151515151515151
+    mov     rdx, 0xDDDDDDDDDDDDDDDD
+    mov     rcx, 0xCCCCCCCCCCCCCCCC
+    mov     r8,  0x8888888888888888
+    mov     r9,  0x9999999999999999
+
+    // Call syscall.
+    mov     rax, SYSNR_TEST0
+    int     INTERRUPT_SYSCALL_VEC
+
+    call    reset_syscall
+
+    // Check flag.
+    cmp     BYTE PTR [syscall_param_unpack_test_flag], 0x1
+    sete    al
+    movzx   rax, al
+    leave
+    ret
+REGISTER_TEST64(syscall_param_unpack_test)
+
+// ============================================================================= 
+// Handler for SYSNR_TEST0 in syscall_param_unpack_test. This routine will
+// compare the value of RDI, RSI, RDX, RCX, R8 and R9 with their respective
+// value before the syscall. If they match then it sets the
+// syscall_param_unpack_test_flag to 0x1, else it sets it to 0x0.
+// ============================================================================= 
+ASM_FUNC_DEF64(syscall_param_unpack_test_handler):
+    mov     rax, 0xD1D1D1D1D1D1D1D1
+    cmp     rdi, rax
+    jne     ._syscall_param_unpack_test_handler_fail
+    mov     rax, 0x5151515151515151
+    cmp     rsi, rax
+    jne     ._syscall_param_unpack_test_handler_fail
+    mov     rax, 0xDDDDDDDDDDDDDDDD
+    cmp     rdx, rax
+    jne     ._syscall_param_unpack_test_handler_fail
+    mov     rax, 0xCCCCCCCCCCCCCCCC
+    cmp     rcx, rax
+    jne     ._syscall_param_unpack_test_handler_fail
+    mov     rax,  0x8888888888888888
+    cmp     r8,  rax
+    jne     ._syscall_param_unpack_test_handler_fail
+    mov     rax,  0x9999999999999999
+    cmp     r9,  rax
+    jne     ._syscall_param_unpack_test_handler_fail
+    // Success.
+    mov     BYTE PTR [syscall_param_unpack_test_flag], 0x1
+    ret
+._syscall_param_unpack_test_handler_fail:
+    // Failure.
+    mov     BYTE PTR [syscall_param_unpack_test_flag], 0x0
+    ret
+
+.section .data
+// Success flag for syscall_param_unpack_test.
+syscall_param_unpack_test_flag:
+.byte   0x0
+
+
+// ============================================================================= 
+// This test checks that the return value of a syscall handler is correctly
+// reported into the RAX register in the interrupted context after the IRET.
+// ============================================================================= 
+ASM_FUNC_DEF64(syscall_return_value_test):
+    push    rbp
+    mov     rbp, rsp
+
+    call    init_syscall
+
+    // Register the temp handler.
+    mov     rdi, SYSNR_TEST0
+    lea     rsi, [syscall_return_value_test_handler]
+    call    _set_test_handler
+
+    // Choose a "random" value for the return value. Use the TSC for that. Make
+    // sure RAX has its upper DWORD non-zero.
+    rdtsc
+    mov     rdx, rax
+    not     rdx
+    shl     rdx, 32
+    or      rax, rdx
+    mov     [syscall_return_value_test_expected_rax], rax
+
+    // Exec the syscall.
+    mov     rax, SYSNR_TEST0
+    int     INTERRUPT_SYSCALL_VEC
+
+    // Check RAX, it should be equal to the expected value.
+    cmp     rax, [syscall_return_value_test_expected_rax]
+    jne     ._syscall_return_value_test_fail
+
+    // Success
+    mov     rax, 1
+    jmp     ._syscall_return_value_test_end
+._syscall_return_value_test_fail:
+    xor     rax, rax
+._syscall_return_value_test_end:
+    push    rax
+    call    reset_syscall
+    pop     rax
+    leave
+    ret
+REGISTER_TEST64(syscall_return_value_test)
+
+// ============================================================================= 
+// Write syscall_return_value_test_expected_rax into RAX.
+// ============================================================================= 
+ASM_FUNC_DEF64(syscall_return_value_test_handler):
+    mov     rax, [syscall_return_value_test_expected_rax]
+    ret
+
+.section .data
+// The value of RAX to be returned by the syscall_return_value_test_handler.
+syscall_return_value_test_expected_rax:
+.quad   0x0

--- a/bootstrap/tests/syscall.S
+++ b/bootstrap/tests/syscall.S
@@ -234,3 +234,26 @@ ASM_FUNC_DEF64(syscall_return_value_test_handler):
 // The value of RAX to be returned by the syscall_return_value_test_handler.
 syscall_return_value_test_expected_rax:
 .quad   0x0
+
+// ============================================================================= 
+// Test the SYSNR_GET_TSC_FREQ syscall.
+// ============================================================================= 
+ASM_FUNC_DEF64(syscall_get_tsc_freq_test):
+    push    rbp
+    mov     rbp, rsp
+
+    call    init_syscall
+
+    mov     rax, SYSNR_GET_TSC_FREQ
+    int     INTERRUPT_SYSCALL_VEC
+
+    cmp     rax, [TSC_FREQ]
+    sete    al
+    movzx   rax, al
+
+    push    rax
+    call    reset_syscall
+    pop     rax
+    leave
+    ret
+REGISTER_TEST64(syscall_get_tsc_freq_test)

--- a/bootstrap/tests/test_macros.h
+++ b/bootstrap/tests/test_macros.h
@@ -5,5 +5,18 @@
     __test_table_str_ ## test_name:     ;\
     .asciz #test_name                   ;\
     .section .data.test_table           ;\
+    .byte 32                            ;\
+    .long __test_table_str_##test_name  ;\
+    .long test_name
+
+// Register a test in the test table to be executed by the run_tests routine.
+// 64-bit version.
+// @param test_name: The name of the test routine.
+#define REGISTER_TEST64(test_name)      ;\
+    .section .data                      ;\
+    __test_table_str_ ## test_name:     ;\
+    .asciz #test_name                   ;\
+    .section .data.test_table           ;\
+    .byte 64                            ;\
     .long __test_table_str_##test_name  ;\
     .long test_name

--- a/bootstrap/tests/tests.S
+++ b/bootstrap/tests/tests.S
@@ -117,7 +117,7 @@ loop:
     add     esp, 4
 
     push    '\n'
-    call    putc_vga_buffer32
+    call    _putc32
     add     esp, 4
 
     // Move to next entry in test table.

--- a/bootstrap/tests/tests.S
+++ b/bootstrap/tests/tests.S
@@ -13,15 +13,20 @@
 // To add a new test one simply needs to define the test routine and then call
 // the REGISTER_TEST(<test_name>) macro.
 // Registered tests are put in the "Test table" which is simply an array of
-// pair (<test routine address>,<address to string containing test name>).
-// The run_tests routine will iterate through the table and execute all tests it
-// finds there while reporting successes and errors.
+// tuples (<test mode>, <test name address>,<test routine address>). The <test
+// mode> is a byte value equal to 32 or 64 indicating the mode required to run
+// the test.
+// The run_tests32 and run_tests64 routines will iterate through the table and
+// execute all tests it finds there while reporting successes and errors.
 // Note: The test table is put in a special data section called .data.test_table
 
+// Offset of the mode in a test table entry.
+.set TEST_TABLE_MODE_OFF, 0x0
 // Offset of the pointer to test routine in a test table entry.
-.set TEST_TABLE_FUNC_NAME_OFF, 0x0
+.set TEST_TABLE_FUNC_NAME_OFF, 0x1
 // Offset of the pointer to test name in a test table entry.
-.set TEST_TABLE_FUNC_PTR_OFF, 0x4
+.set TEST_TABLE_FUNC_PTR_OFF, 0x5
+.set TEST_TABLE_ENTRY_SIZE, 0x9
 
 // ============================================================================= 
 // Check that no callee saved register has been clobbered during a test. This
@@ -55,11 +60,13 @@ ASM_FUNC_DEF32(_check_callee_save_registers):
     ret
 
 // ============================================================================= 
-// Execute all tests registered in the test table and print a summary.
+// Execute all 32-bit tests registered in the test table and print a summary.
 // ============================================================================= 
-ASM_FUNC_DEF32(run_tests):
+ASM_FUNC_DEF32(run_tests32):
     push    ebp
     mov     ebp, esp
+
+    INFO32("Running 32-bit tests\n")
     
     // Local variables:
     // EBP - 0x4: Number of tests ran so far.
@@ -76,6 +83,12 @@ ASM_FUNC_DEF32(run_tests):
 
     jmp     cond
 loop:
+    // AL = Mode of the test.
+    mov     al, [ebx + TEST_TABLE_MODE_OFF]
+    cmp     al, 32
+    // If the mode is not 32-bits skip the test.
+    jne     next
+
     // EAX = Address of test routine.
     mov     eax, [ebx + TEST_TABLE_FUNC_PTR_OFF] 
 
@@ -120,8 +133,9 @@ loop:
     call    _putc32
     add     esp, 4
 
+next:
     // Move to next entry in test table.
-    add     ebx, 8
+    add     ebx, TEST_TABLE_ENTRY_SIZE
 cond:
     lea     eax, [TEST_TABLE_END]
     cmp     ebx, eax
@@ -148,5 +162,151 @@ cond:
 
 1:
     pop     ebx
+    leave
+    ret
+
+// ============================================================================= 
+// Check that no callee saved register has been clobbered during a 64-bit test.
+// This can catch a lot of accidental clobbering (from implementation or even
+// tests themselves) but not all unfortunately.
+// No arguments and no return, however RSP is expected to point on saved
+// registers before calling this function.
+// This routine will panic if any clobbering is detected.
+// ============================================================================= 
+ASM_FUNC_DEF64(_check_callee_save_registers64):
+    // RAX = pointer to saved registers.
+    lea     rax, [rsp + 8]
+
+    cmp     r15, [rax + 0 * 0x8]
+    jne     0f
+    cmp     r14, [rax + 1 * 0x8]
+    jne     0f
+    cmp     r13, [rax + 2 * 0x8]
+    jne     0f
+    cmp     r12, [rax + 3 * 0x8]
+    jne     0f
+    cmp     rbp, [rax + 4 * 0x8]
+    jne     0f
+    cmp     rbx, [rax + 5 * 0x8]
+    jne     0f
+
+    jmp     1f
+0:
+    PANIC64("Register clobbering detected!\n")
+    // Unreachable
+    int3
+1:
+    ret
+
+// ============================================================================= 
+// Execute all 64-bit tests registered in the test table and print a summary.
+// ============================================================================= 
+ASM_FUNC_DEF64(run_tests64):
+    push    rbp
+    mov     rbp, rsp
+
+    INFO64("Running 64-bit tests\n")
+
+    // Local variables:
+    // RBP - 0x8: Number of tests ran so far.
+    // RBP - 0x10: Number of successful test so far.
+    // RBP - 0x18: Return value of last test.
+    push    0x0
+    push    0x0
+    push    0x0
+
+    push    rbx
+
+    // RBX = Address in test table.
+    lea     rbx, [TEST_TABLE_START]
+
+    jmp     ._run_tests64_loop_cond
+._run_tests64_loop:
+    // AL = Mode of the test.
+    mov     al, [ebx + TEST_TABLE_MODE_OFF]
+    cmp     al, 64
+    // If the mode is not 64-bits skip the test.
+    jne     ._run_tests64_loop_next
+
+    // RAX = Address of test routine.
+    // Note: The adddresses in the test table are 32-bit.
+    mov     eax, [rbx + TEST_TABLE_FUNC_PTR_OFF]
+
+    // Push the callee-saved registers onto the stack right before calling the
+    // test. We will use these saved values to detect any register clobbering.
+    // 64-bit callee-saved registers: RBX, RBP, R12 -> R15
+    push    rbx
+    push    rbp
+    push    r12
+    push    r13
+    push    r14
+    push    r15
+
+    // Run the test
+    call    rax
+    // Save return value during call to _check_callee_save_registers.
+    mov     [rbp - 0x18], rax
+
+    // Check that no callee-saved register has been clobbered.
+    call    _check_callee_save_registers64
+    // Remove saved registers.
+    add     rsp, 6 * 8
+
+    // Increment the number of tests ran.
+    inc     QWORD PTR [rbp - 0x8]
+
+    // Print correct prefix depending on the outcome of the test.
+    mov     rax, [rbp - 0x18]
+    test    rax, rax
+    jnz     0f
+
+    // Test was a failure. Print failure prefix.
+    _PRINTF64("[TEST ] [FAIL] :", "")
+    jmp     1f
+
+0:
+    // Test was a success. Print success prefix.
+    _PRINTF64("[TEST ] [ OK ] :", "")
+    // And increase successes count.
+    inc     QWORD PTR [rbp - 0x10]
+
+1:
+    // Print test name.
+    // Note: Addresses are 32-bit in a table entry.
+    mov     edi, [rbx + TEST_TABLE_FUNC_NAME_OFF]
+    call    printf64
+
+    mov     rdi, '\n'
+    call    _putc64
+
+._run_tests64_loop_next:
+    // Move to next entry in test table.
+    add     rbx, TEST_TABLE_ENTRY_SIZE
+._run_tests64_loop_cond:
+    lea     rax, [TEST_TABLE_END]
+    cmp     rbx, rax
+    jb      ._run_tests64_loop
+
+    // All tests executed print summary.
+    mov     rax, [rbp - 0x8]
+    cmp     rax, [rbp - 0x10]
+    je      0f
+
+    // Not all tests were successful.
+    sub     rax, [rbp - 0x10]
+    push    [rbp - 0x8]
+    push    rax
+    _PRINTF64("[TEST ] [SUMM] :", "%q / %q tests failed!\n")
+    add     rsp, 16
+    jmp     1f
+
+0:
+    // All tests Successful.
+    push    [rbp - 0x8]
+    _PRINTF64("[TEST ] [SUMM] :", "All %q tests passed!\n")
+    add     rsp, 8
+
+1:
+    pop     rbx
     leave
     ret

--- a/bootstrap/tsc.S
+++ b/bootstrap/tsc.S
@@ -1,0 +1,207 @@
+// This file contains routines and state related to the Time-Stamp Counter
+// (TSC).
+// In this project, we use the TSC as a time-keeping counter, this means that we
+// need the TSC to have a _constant_ frequency no matter the state of the CPU
+// (running, idle, freq scaling, ...). Fortunately all recent Intel processors
+// have this feature, this is called "Invariant TSC" and support can be asserted
+// using CPUID.
+// Unfortunately getting the TSC's frequency is an adventure on itself. Intel
+// provides multiple ways to achieve this, but none seem to be portable and in
+// reality it depends on the processor's model. Additionally Qemu gets in our
+// way by hiding some CPUID information and MSRs from the guest (even though we
+// are using the host cpu model, ...). If all fails we can use the PIT to
+// calibrate the TSC's frequency. This is the least precise method but it yields
+// decent results, and it works in Qemu VMs.
+//
+// Here are the three methods to get the TSC's frequency:
+//  1. Using CPUID.15H. This execution to CPUID will give enough information to
+//  compute the frequency. Unfortunately, not all cpus implement CPUID.15H. The
+//  precision using this method is high.
+//  2. Using the MSR_PLATFORM_INFO (0xCE). This MSR gives the "Maximum Non-Turbo
+//  Ratio". This ration can be used to compute the TSC's frequency. Using this
+//  method precision is high.
+//  3. Using the PIT. Precision is medium to poor but is usually sufficient.
+// Upon calling init_tsc, each method will be tried (in the order above) to find
+// the TSC's frequency.
+
+#include <asm_macros.h>
+#include <consts.h>
+
+.intel_syntax   noprefix
+
+.section .data
+// The frequency of the TSC in Hz.
+.global TSC_FREQ
+TSC_FREQ:
+.quad   0x0
+
+// =============================================================================
+// Read the current value of the TSC.
+// @return (RAX): The value of TSC.
+// =============================================================================
+ASM_FUNC_DEF64(read_tsc):
+    rdtsc
+    shl     rdx, 32
+    or      rax, rdx
+    ret
+
+// =============================================================================
+// Calibrate the TSC.
+// =============================================================================
+ASM_FUNC_DEF64(init_tsc):
+    push    rbp
+    mov     rbp, rsp
+
+    // First detect for the invariant TSC extension, this is indicated by
+    // CPUID.80000007H:EDX[8]. This feature is required for this project.
+    mov     eax, 0x80000007
+    cpuid
+    test    edx, (1 << 8)
+    jnz     0f
+    PANIC64("init_tsc: Processor does not support Invariant TSC extension")
+0:
+
+    // Try each method to get the TSC's frequency.
+    // Using CPUID:
+    call    _calibrate_tsc_cpuid
+    test    rax, rax
+    jnz     ._init_tsc_freq_found
+    WARN64("init_tsc: _calibrate_tsc_cpuid failed\n")
+
+    // Using the MSR:
+    call    _calibrate_tsc_msr
+    test    rax, rax
+    jnz     ._init_tsc_freq_found
+    WARN64("init_tsc: _calibrate_tsc_msr failed\n")
+
+    // If nothing works, then we use PIT.
+    INFO64("init_tsc: Fallback to PIT calibration\n")
+    call    _calibrate_tsc_pit
+
+._init_tsc_freq_found:
+    mov     [TSC_FREQ], rax
+
+    push    rax
+    INFO64("TSC_FREQ = %q Hz\n")
+    pop     rax
+
+    leave
+    ret
+
+// =============================================================================
+// Calibrate the TSC's frequency using the "CPUID method":
+// According to the CPUID documentation, the TSC's frequency can be computed
+// using the following information from the Time Stamp Counter and Nominal Core
+// Crystal Clock Information Leaf (15H):
+//  - EAX Bits 31 - 00: An unsigned integer which is the denominator of the
+//  TSC/”core crystal clock” ratio.
+//  - EBX Bits 31 - 00: An unsigned integer which is the numerator of the
+//  TSC/”core crystal clock” ratio.
+//  - ECX Bits 31 - 00: An unsigned integer which is the nominal frequency of
+//  the core crystal clock in Hz.
+// The TSC's frequency is therefore:
+//  Ftsc = ECX * EBX / EAX
+//
+// Unfortunately, this is not implemented by every CPU. If EBX or ECX is 0 then
+// this is not supported.
+// Another issue is if the max EAX value accepted by CPUID is < 0x15.
+//
+// @return (RAX): On success the computed frequency of the TSC in hz, 0
+// otherwise.
+// =============================================================================
+ASM_FUNC_DEF64(_calibrate_tsc_cpuid):
+    push    rbp
+    mov     rbp, rsp
+
+    // Check that the max input value of CPUID is >= 0x15.
+    xor     eax, eax
+    cpuid
+    cmp     eax, 0x15
+    jae     0f
+
+    // The processor does not support EAX >= 0x15 with cpuid. Give up.
+    WARN64("_calibrate_tsc_cpuid: CPU does not support 0x15 CPUID leaf\n")
+    xor     rax, rax
+    leave
+    ret
+
+0:
+    // We can give EAX = 0x15 as input to CPUID. Do this and look if the output
+    // is complete to compute the frequency.
+    mov     eax, 0x15
+    cpuid
+
+    push    rcx
+    push    rbx
+    push    rax
+    DEBUG64("CPUID.15H: RAX = %q RBX = %q RCX = %q\n")
+    pop     rax
+    pop     rbx
+    pop     rcx
+
+    test    rbx, rbx
+    jnz     0f
+    WARN64("_calibrate_tsc_cpuid: CPUID.15H does not enumerate numerator\n")
+    xor     rax, rax
+    leave
+    ret
+
+0:
+    test    rcx, rcx
+    jnz     0f
+    WARN64("_calibrate_tsc_cpuid: CPUID.15H does not enumerate clock freq\n")
+    xor     rax, rax
+    leave
+    ret
+
+0:
+    // We have all the necessary information to compute the frequency equation.
+    // Swap EAX and EBX so that we can do the MUL before the DIV.
+    // Note: The equation becomes: Ftsc = ECX * EAX / EBX
+    xchg    rax, rbx
+    mul     rcx
+    // RAX = Freq.
+    div     rbx
+
+    leave
+    ret
+
+
+// =============================================================================
+// Compute the TSC's frequency using the MSR_PLATFORM_INFO.
+// =============================================================================
+ASM_FUNC_DEF64(_calibrate_tsc_msr):
+    push    rbp
+    mov     rbp, rsp
+    
+    // Using the MSR, computing the TSC's frequency is easy, we simply need to
+    // read MSR_PLATFORM_INFO. Bits[15:8] gives the ratio, multiplying this
+    // ratio by 100MHz (or 133.33MHz) gives the TSC's frequency.
+.set MSR_PLATFORM_INFO, 0xCE
+    mov     ecx, MSR_PLATFORM_INFO
+    rdmsr
+    shr     eax, 8
+    movsx   rax, al
+
+    // On micro-architecture different than Nephalem, we need to multiply the
+    // ratio by 100MHz to obtain the TSC's frequency. With Nephalem this should
+    // be 133.33MHz, however those are ancient micro-architecture and therefore
+    // we won't care about them.
+    imul    rax, rax, 100000000
+
+    leave
+    ret
+
+// =============================================================================
+// Compute the TSC's frequency using PIT calibration. This method is sure to be
+// successful, albeit with potentially reduced precision.
+// @return (RAX): On success the computed frequency of the TSC in hz, 0
+// otherwise.
+// =============================================================================
+ASM_FUNC_DEF64(_calibrate_tsc_pit):
+    push    rbp
+    mov     rbp, rsp
+    lea     rdi, [read_tsc]
+    call    calibrate_counter_with_pit
+    leave
+    ret

--- a/bootstrap/video.S
+++ b/bootstrap/video.S
@@ -97,7 +97,7 @@ ASM_FUNC_DEF32(_read_vbe_info_block):
     push    ecx
     call    printf32
     push    '\n'
-    call    putc_vga_buffer32
+    call    _putc32
     add     esp, 8
 
     // Return the address of the copy.

--- a/bootstrap/video.S
+++ b/bootstrap/video.S
@@ -1,0 +1,264 @@
+// This file contains code related to video framebuffer initialization and
+// configuration.
+// The webpage https://wiki.osdev.org/Getting_VBE_Mode_Info is a great source of
+// information on how to interact with the BIOS to get info about VESA video
+// mode.
+
+#include <asm_macros.h>
+#include <consts.h>
+
+.intel_syntax   noprefix
+
+// The next few consts define the video mode that we want to use. The init_video
+// routine will try to find this video mode. If it succeed then the video mode
+// is set, otherwise it panics.
+// Width in pixel.
+.set PREFERRED_WIDTH, 1920
+// Height in pixel.
+.set PREFERRED_HEIGHT, 1080
+// Number of bytes per pixel.
+.set PREFERRED_BPP, 32
+// The type of framebuffer. See http://www.ctyme.com/intr/rb-0274.htm
+// 0x6 indicate direct color.
+.set PREFERRED_MEM_MODEL, 6
+
+// Data used in this file.
+.section .data
+// Pointer on a copy of the VBE info block. This points to allocated memory that
+// contains the returned info from the BIOS when executing the "Get Controller
+// Info" function (int 0x10 AX = 0x4F00).
+vbe_info_block:
+.quad   0x0
+// Pointer on a copy of the video mode info block. This points to allocated
+// memory as well. This is the information reported by the "Get Mode Info"
+// function. This will contain info on the current video mode after the call to
+// init_video.
+.global mode_info_block
+mode_info_block:
+.quad   0x0
+
+// The size of the VBE info block in bytes.
+.set VBE_INFO_BLOCK_SIZE, 512
+// Some offsets of fields in the VBE info block. Note: In the definition below,
+// a "real mode far pointer" is defined as a 32-bit dword of the form <real mode
+// segment>:<offset>.
+// (DWORD) real mode far pointer to the OEM string.
+.set VBE_INFO_BLOCK_OEM_OFF, 0x6
+// (DWORD) real mode far pointer to the array of available video modes.
+.set VBE_INFO_BLOCK_MODE_PTR_OFF, 0xE
+
+// ============================================================================= 
+// Read the VBE info block from the BIOS and store it in accessible RAM
+// (dynamically allocated).
+// @return (EAX): Pointer to the copy of the VBE info block.
+// Note: This routine will also set the `vbe_info_block` pointer.
+// ============================================================================= 
+ASM_FUNC_DEF32(_read_vbe_info_block):
+    push    ebp
+    mov     ebp, esp
+
+    // Allocate enough space to contain the VBE info block.
+    push    VBE_INFO_BLOCK_SIZE
+    call    allocate_low_mem
+    mov     [vbe_info_block], eax 
+
+    // Call the "Get Controller Info" BIOS function. Int 0x10/AX = 0x4F00.
+    sub     esp, BCP_SIZE
+    mov     BYTE PTR [esp + BCP_INT_OFF], 0x10
+    mov     DWORD PTR [esp + BCP_EAX_OFF], 0x4F00
+    // EDI points to the destination where to write the information.
+    mov     DWORD PTR [esp + BCP_EDI_OFF], eax
+    push    esp
+    call    call_bios_func_32
+    add     esp, 4
+
+    // VBE functions will return 0x004F in AX on success.
+    cmp     WORD PTR [esp + BCP_EAX_OFF], 0x004F
+    je      0f
+    PANIC32("_read_vbe_info_block: Error when getting controller info\n")
+0:
+    add     esp, BCP_SIZE
+
+    // Check the signature of the block. It should be "VESA".
+    mov     eax, [vbe_info_block]
+    cmp     DWORD PTR [eax], 0x41534556
+    je      0f
+    PANIC32("_read_vbe_info_block: Invalid signature\n")
+0:
+
+    // Print OEM string in logs.
+    INFO32("Found VBE info OEM = ")
+    // ECX = Addr of string.
+    mov     eax, [vbe_info_block]
+    movzx   ecx, WORD PTR [eax + VBE_INFO_BLOCK_OEM_OFF + 2]
+    shl     ecx, 4
+    movzx   edx, WORD PTR [eax + VBE_INFO_BLOCK_OEM_OFF]
+    add     ecx, edx
+    push    ecx
+    call    printf32
+    push    '\n'
+    call    putc_vga_buffer32
+    add     esp, 8
+
+    // Return the address of the copy.
+    mov     eax, [vbe_info_block]
+    leave
+    ret
+
+// The size of the mode info block in bytes.
+.set MODE_INFO_BLOCK_SIZE, 256
+// Some offsets of the mode info block's fields used during init:
+// (WORD) Width in pixels.
+.set MODE_INFO_BLOCK_WIDTH_OFF, 0x12
+// (WORD) Height in pixels.
+.set MODE_INFO_BLOCK_HEIGHT_OFF, 0x14
+// (WORD) Mode's attributes.
+.set MODE_INFO_BLOCK_ATTR_OFF, 0x0
+// (BYTE) Memory model type. See http://www.ctyme.com/intr/rb-0274.htm#Table82.
+.set MODE_INFO_BLOCK_MEM_MODEL, 0x1B
+// (DWORD) Physical address of the mode's framebuffer. If applicable.
+.set MODE_INFO_BLOCK_FB_ADDR_OFF, 0x28
+// (BYTE) Number of bits per pixels.
+.set MODE_INFO_BLOCK_BPP, 0x19
+// (WORD) Number of bytes per line. This is used to compute the offset of the
+// start of a line as follows: offset = line_num * bytes_per_line.
+.set MODE_INFO_BLOCK_BYTE_PER_LINE, 0x10
+
+// ============================================================================= 
+// Initialize the video mode. This routine will use the BIOS' VESA functions to
+// find the mode corresponding to the requested resolution (PREFERRED_*) and set
+// it. If no such mode is found it will panic.
+// WARN: After calling this function, the VGA text buffer will not be available
+// anymore.
+// ============================================================================= 
+ASM_FUNC_DEF32(init_video):
+    push    ebp
+    mov     ebp, esp
+
+    push    ebx
+    push    edi
+
+    // EAX = Pointer on VBE info block.
+    call    _read_vbe_info_block
+
+    // EBX = Pointer on mode array. The pointer is a <real mode segment>:offset
+    // pair.
+    movzx   ebx, WORD PTR [eax + VBE_INFO_BLOCK_MODE_PTR_OFF + 2]
+    shl     ebx, 4
+    movzx   edx, WORD PTR [eax + VBE_INFO_BLOCK_MODE_PTR_OFF]
+    add     ebx, edx
+
+    // Allocate space for the mode info block.
+    push    MODE_INFO_BLOCK_SIZE
+    call    allocate_low_mem
+    add     esp, 4
+    mov     [mode_info_block], eax
+    // EDI = mode info block addr.
+    mov     edi, eax
+    
+    jmp     video_loop_cond
+    // Loop over all modes in the mode ptr and find a graphical mode with linear
+    // framebuffer that corresponds to our preferred resolution.
+video_loop:
+    // Call the "Get Mode Info" BIOS function. Int 0x10/AX = 0x4F01.
+    sub     esp, BCP_SIZE
+    mov     BYTE PTR [esp + BCP_INT_OFF], 0x10
+    mov     DWORD PTR [esp + BCP_EAX_OFF], 0x4F01
+    mov     ax, [ebx]
+    mov     WORD PTR [esp + BCP_ECX_OFF], ax
+    mov     DWORD PTR [esp + BCP_EDI_OFF], edi
+    push    esp
+    call    call_bios_func_32
+    add     esp, 4
+    cmp     WORD PTR [esp + BCP_EAX_OFF], 0x004F
+    je      0f
+    PANIC32("init_video: Couldn't read mode info\n")
+0:
+    add     esp, BCP_SIZE
+
+    // Check if this is a graphic mode with a linear frame buffer. This is done
+    // by checking the OR 0x90 (bit 7 indicate support for framebuffer and bit 4
+    // graphic mode).
+    mov     ax, [edi + MODE_INFO_BLOCK_ATTR_OFF] 
+    and     ax, 0x90
+    cmp     ax, 0x90
+    jne     video_loop_next
+
+    // Check memory model.
+    mov     al, [edi + MODE_INFO_BLOCK_MEM_MODEL]
+    cmp     al, PREFERRED_MEM_MODEL
+    jne     video_loop_next
+
+    // Check bits per pixel.
+    mov     al, [edi + MODE_INFO_BLOCK_BPP]
+    cmp     al, PREFERRED_BPP
+    jne     video_loop_next
+
+    // Compare with preferred resolution.
+    cmp     WORD PTR [edi + MODE_INFO_BLOCK_WIDTH_OFF], PREFERRED_WIDTH
+    jne     video_loop_next
+    cmp     WORD PTR [edi + MODE_INFO_BLOCK_HEIGHT_OFF], PREFERRED_HEIGHT
+    jne     video_loop_next
+
+    // This is the mode we want.
+    jmp     video_loop_found
+
+video_loop_next:
+    add     ebx, 2
+video_loop_cond:
+    cmp     DWORD PTR [ebx], 0xFFFF
+    jne     video_loop
+
+    // We reached the end of the list and we haven't found the requested mode.
+    // Give up.
+    PANIC32("init_video: Could not find requested video mode\n")
+
+video_loop_found:
+    // Requested video mode is available and it stored under mode_info_block
+    // (pointed by EDI).
+    push    [ebx]
+    push    PREFERRED_HEIGHT
+    push    PREFERRED_WIDTH
+    INFO32("Video mode %w x %w found: %w\n")
+    add     esp, 0xC
+
+    // Set the video mode.
+    push    [ebx]
+    call    _set_video_mode
+    add     esp, 4
+
+    pop     edi
+    pop     ebx
+
+    leave
+    ret
+
+// ============================================================================= 
+// Set the current video mode.
+// @param (DWORD) mode number as reported in the VBE info block.
+// ============================================================================= 
+ASM_FUNC_DEF32(_set_video_mode):
+    push    ebp
+    mov     ebp, esp
+
+    // Call the Set Video Mode BIOS function int 0x10, ax = 0x4f02.
+    sub     esp, BCP_SIZE
+    mov     BYTE PTR [esp + BCP_INT_OFF], 0x10
+    mov     DWORD PTR [esp + BCP_EAX_OFF], 0x4F02
+    // BX should hold the mode number. Additionally we should OR it by 0x4000 to
+    // indicate that we want to use the linear framebuffer. See
+    // https://wiki.osdev.org/Getting_VBE_Mode_Info.
+    mov     ax, [ebx]
+    or      ax, 0x4000
+    mov     WORD PTR [esp + BCP_EBX_OFF], ax
+    push    esp
+    call    call_bios_func_32
+    add     esp, 4
+
+    cmp     WORD PTR [esp + BCP_EAX_OFF], 0x004F
+    je      0f
+    PANIC32("init_video: Couldn't set video mode\n")
+0:
+    add     esp, BCP_SIZE
+    leave
+    ret

--- a/bootstrap/video.S
+++ b/bootstrap/video.S
@@ -262,3 +262,59 @@ ASM_FUNC_DEF32(_set_video_mode):
     add     esp, BCP_SIZE
     leave
     ret
+
+// ============================================================================= 
+// Map the VESA frame buffer to the virtual address space. This routine will use
+// ID mapping. This must be called _after_ setting the video mode.
+// ============================================================================= 
+ASM_FUNC_DEF64(map_framebuffer):
+    push    rbp
+    mov     rbp, rsp
+
+    push    rbx
+
+    // RAX = Pointer on mode info.
+    mov     rax, [mode_info_block]
+    // RCX = Size of the framebuffer in bytes.
+    //     = (height - 1) * bytes_per_line + width * (bits_per_pixel/8)
+    movzx   rcx, WORD PTR [rax + MODE_INFO_BLOCK_HEIGHT_OFF]
+    dec     rcx
+    movzx   rdx, WORD PTR [rax + MODE_INFO_BLOCK_BYTE_PER_LINE]
+    imul    rcx, rdx
+    movzx   rdx, WORD PTR [rax + MODE_INFO_BLOCK_WIDTH_OFF]
+    movzx   r12, BYTE PTR [rax + MODE_INFO_BLOCK_BPP]
+    imul    rdx, r12
+    shr     rdx, 3
+    add     rcx, rdx
+
+    // RCX = Size of the frame buffer in number of pages.
+    test    rcx, (PAGE_SIZE - 1)
+    setnz   dl
+    movzx   rdx, dl
+    shr     rcx, 12
+    add     rcx, rdx
+
+    push    rax
+    push    rcx
+    DEBUG64("Framebuffer size = %q pages\n")
+    pop     rcx
+    pop     rax
+    
+    // RBX = Next address to map.
+    mov     ebx, [rax + MODE_INFO_BLOCK_FB_ADDR_OFF]
+map_framebuffer_loop:
+    push    rcx
+    mov     rdi, rbx
+    mov     rsi, rbx
+    mov     rdx, (MAP_WRITE | MAP_WRITE_THROUGH | MAP_CACHE_DISABLE)
+    call    map_frame
+
+    add     rbx, PAGE_SIZE
+    pop     rcx
+    loop    map_framebuffer_loop
+
+    INFO64("Framebuffer mapped to virtual memory\n")
+
+    pop     rbx
+    leave
+    ret

--- a/src/Makefile
+++ b/src/Makefile
@@ -10,7 +10,7 @@ CC=g++
 # 	-fno-rtti: No runtime support (at least yet).
 # 	-mno-red-zone: Disable red zone on the stack (128 bytes under current RSP).
 # 	This is because the kernel does not switch stacks on interrupts.
-CPPFLAGS=-ffreestanding -static -nostdlib -fno-exceptions -fno-rtti -mno-red-zone
+CPPFLAGS=-ffreestanding -static -nostdlib -fno-exceptions -fno-rtti -mno-red-zone -std=c++17
 
 SRC_DIR=./
 SOURCE_FILES:=$(shell find $(SRC_DIR) -type f -name "*.cpp")

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,11 +8,14 @@ CC=g++
 # 	-nostdlib: Same as -static.
 # 	-fno-exceptions: Exceptions are not supported since they required a library.
 # 	-fno-rtti: No runtime support (at least yet).
-CPPFLAGS=-ffreestanding -static -nostdlib -fno-exceptions -fno-rtti
+# 	-mno-red-zone: Disable red zone on the stack (128 bytes under current RSP).
+# 	This is because the kernel does not switch stacks on interrupts.
+CPPFLAGS=-ffreestanding -static -nostdlib -fno-exceptions -fno-rtti -mno-red-zone
 
 SRC_DIR=./
 SOURCE_FILES:=$(shell find $(SRC_DIR) -type f -name "*.cpp")
-OBJ_FILES:=$(SOURCE_FILES:.cpp=.o)
+ASM_FILES:=$(shell find $(SRC_DIR) -type f -name "*.S")
+OBJ_FILES:=$(SOURCE_FILES:.cpp=.o) $(ASM_FILES:.S=.o)
 
 # Final executable name.
 FILENAME=Krayte
@@ -23,6 +26,8 @@ $(FILENAME): $(OBJ_FILES)
 	$(CC) -o $@ $(CPPFLAGS) $^
 
 %.o: %.cpp
+	$(CC) -c -o $@ $(CPPFLAGS) $<
+%.o: %.S
 	$(CC) -c -o $@ $(CPPFLAGS) $<
 
 .PHONY: clean

--- a/src/asm.S
+++ b/src/asm.S
@@ -13,6 +13,7 @@ readTsc:
 .set SYSCALL_INTERRUPT_VECTOR, 0x21
 // Syscall number for GET_TSC_FREQ.
 .set SYSNR_GET_TSC_FREQ, 0x2
+.set SYSNR_LOG_SERIAL, 0x3
 
 .section .text
 .code64
@@ -20,5 +21,14 @@ readTsc:
 .type   getTscFreq, @function
 getTscFreq:
     mov     rax, SYSNR_GET_TSC_FREQ
+    int     SYSCALL_INTERRUPT_VECTOR
+    ret
+
+.section .text
+.code64
+.global logSerial
+.type   logSerial, @function
+logSerial:
+    mov     rax, SYSNR_LOG_SERIAL
     int     SYSCALL_INTERRUPT_VECTOR
     ret

--- a/src/asm.S
+++ b/src/asm.S
@@ -1,0 +1,24 @@
+.intel_syntax   noprefix
+.section .text
+.code64
+.global readTsc
+.type   readTsc, @function
+readTsc:
+    rdtsc
+    shl     rdx, 32
+    or      rax, rdx
+    ret
+
+// Interrupt vector used for syscalls through software interrupts.
+.set SYSCALL_INTERRUPT_VECTOR, 0x21
+// Syscall number for GET_TSC_FREQ.
+.set SYSNR_GET_TSC_FREQ, 0x2
+
+.section .text
+.code64
+.global getTscFreq
+.type   getTscFreq, @function
+getTscFreq:
+    mov     rax, SYSNR_GET_TSC_FREQ
+    int     SYSCALL_INTERRUPT_VECTOR
+    ret

--- a/src/asm.S
+++ b/src/asm.S
@@ -14,6 +14,7 @@ readTsc:
 // Syscall number for GET_TSC_FREQ.
 .set SYSNR_GET_TSC_FREQ, 0x2
 .set SYSNR_LOG_SERIAL, 0x3
+.set SYSNR_SBRK, 0x4
 
 .section .text
 .code64
@@ -30,5 +31,14 @@ getTscFreq:
 .type   logSerial, @function
 logSerial:
     mov     rax, SYSNR_LOG_SERIAL
+    int     SYSCALL_INTERRUPT_VECTOR
+    ret
+
+.section .text
+.code64
+.global sbrk
+.type   sbrk, @function
+sbrk:
+    mov     rax, SYSNR_SBRK
     int     SYSCALL_INTERRUPT_VECTOR
     ret

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,13 +62,145 @@ class VGABuffer {
             }
         }
 };
+
+// Information on the VESA frame buffer.
+struct FrameBufferInfo {
+    // Number of bytes per-line. Note that this is not necessarily "width *
+    // bitsPerPixel / 8" since there might be padding between lines.
+    uint16_t const bytesPerLine;
+    // The width in pixels.
+    uint16_t const width;
+    // The height in pixels.
+    uint16_t const height;
+    // Reserved, do not touch.
+    uint8_t reserved[3];
+    // The number of bits per pixels.
+    uint8_t const bitsPerPixel;
+    // Reserved, do not touch.
+    uint8_t reserved2[5];
+    // The size of the red mask in number of bits.
+    uint8_t const redMaskSize;
+    // The position of the red mask in number of bits from bit 0.
+    uint8_t const redMaskPos;
+    // The size of the green mask in number of bits.
+    uint8_t const greenMaskSize;
+    // The position of the green mask in number of bits from bit 0.
+    uint8_t const greenMaskPos;
+    // The size of the blue mask in number of bits.
+    uint8_t const blueMaskSize;
+    // The position of the green mask in number of bits from bit 0.
+    uint8_t const blueMaskPos;
+    // Reserved, do not touch.
+    uint8_t reserved3[3];
+    // The address of the framebuffer. This is under 4GiB hence the uint32_t.
+    uint32_t const framebufferAddr;
+} __attribute__((packed));
+
+// Abstraction of the VESA framebuffer.
+class FrameBuffer {
+    public:
+    // Create an instance of FrameBuffer from a FrameBufferInfo.
+    // @param fbInfo: The FrameBufferInfo.
+    FrameBuffer(struct FrameBufferInfo const * const fbInfo) : fbInfo(fbInfo) {}
+
+    // Color class used by the frame buffer.
+    class Color {
+        public:
+        // Create a color instance.
+        // @param r: 8-bit Red component.
+        // @param g: 8-bit Green component.
+        // @param b: 8-bit Blue component.
+        Color(uint8_t const r, uint8_t const g, uint8_t const b) : r(r), g(g), b(b) {}
+
+        // Convert a Color to a uint32_t.
+        // @param fbInfo: Information on the framebuffer. This is used to know
+        // the position and size of the R, G and B masks.
+        // @return: A uint32_t describing this color as understood by the
+        // framebuffer.
+        uint32_t toUint32(struct FrameBufferInfo const * const fbInfo) const {
+            return ((r & ((1<<fbInfo->redMaskSize)-1)) << fbInfo->redMaskPos) |
+            ((g & ((1<<fbInfo->greenMaskSize)-1)) << fbInfo->greenMaskPos) |
+            ((b & ((1<<fbInfo->blueMaskSize)-1)) << fbInfo->blueMaskPos);
+        }
+
+        private:
+        uint8_t const r;
+        uint8_t const g;
+        uint8_t const b;
+    };
+
+    // Position class used to describe a pixel position on the framebuffer.
+    template<typename T>
+    class Pos {
+        public:
+        // Create a positon from two coordinates of type T.
+        Pos(T const x, T const y) : x(x), y(y) {}
+
+        // Get the line index of the position. This version is specialized for
+        // types that can be casted to uint16_t.
+        // @param fbInfo: The information on the framebuffer where the position
+        // will be used.
+        // @return: The index of the line of the position.
+        uint16_t line(struct FrameBufferInfo const * const fbInfo) const {
+            return (uint16_t)y;
+        }
+
+        // Get the column index of the position. This version is specialized for
+        // types that can be casted to uint16_t.
+        // @param fbInfo: The information on the framebuffer where the position
+        // will be used.
+        // @return: The index of the column of the position.
+        uint16_t col(struct FrameBufferInfo const * const fbInfo) const {
+            return (uint16_t)x;
+        }
+
+        private:
+        T const x;
+        T const y;
+    };
+
+    // Draw a pixel on the framebuffer.
+    // @param pos: The position of the pixel.
+    // @param color: The color of the pixel.
+    template<typename T>
+    void putPixel(Pos<T> const& pos, Color const& color) {
+        uint16_t const x = pos.col(fbInfo);
+        uint16_t const y = pos.line(fbInfo);
+        uint8_t * const fb = ((uint8_t*)(uint64_t)fbInfo->framebufferAddr) +
+            (y * fbInfo->bytesPerLine) + x * (fbInfo->bitsPerPixel / 8);
+        *(uint32_t*)fb = color.toUint32(fbInfo);
+    }
+
+    private:
+    struct FrameBufferInfo const * const fbInfo;
+};
+
+// Specialization for the line method for Pos<float>. The y is between 0 and 1.
+template<>
+uint16_t FrameBuffer::Pos<float>::line(struct FrameBufferInfo const * const fbInfo) const {
+    return (uint16_t)(y * fbInfo->height);
+}
+
+// Specialization for the col method for Pos<float>. The x is between 0 and 1.
+template<>
+uint16_t FrameBuffer::Pos<float>::col(struct FrameBufferInfo const * const fbInfo) const {
+    return (uint16_t)(x * fbInfo->width);
+}
+
 }
 
 // The entry point name is expected to be _start. The extern "C" is here to
 // avoid the compiler mangling the name and ld complaining.
-// @param startCursor: The current position of the cursor. This is passed by the
-// boostrap so that the application does not overwrite previous log messages.
-extern "C" void _start(uint16_t const startCursor) {
-    Kr8::VGABuffer buf(startCursor);
-    buf << "Hello world from a 64-bit C++ process!\n";
+// @param fbInfo: FrameBufferInfo struct passed by the bootstrap in order to
+// understand how to interact with the VESA framebuffer.
+extern "C" void _start(Kr8::FrameBufferInfo const * const fbInfo) {
+    Kr8::FrameBuffer fb(fbInfo);
+    fb.putPixel(Kr8::FrameBuffer::Pos<float>(.33f, .33f), Kr8::FrameBuffer::Color(0, 255, 0));
+    fb.putPixel(Kr8::FrameBuffer::Pos<float>(.66f, .33f), Kr8::FrameBuffer::Color(0, 255, 0));
+    fb.putPixel(Kr8::FrameBuffer::Pos<float>(.33f, .66f), Kr8::FrameBuffer::Color(0, 255, 0));
+    fb.putPixel(Kr8::FrameBuffer::Pos<float>(.66f, .66f), Kr8::FrameBuffer::Color(0, 255, 0));
+    for (uint16_t i = 0; i < fbInfo->height; ++i) {
+        uint16_t const x = fbInfo->width / 2;
+        fb.putPixel(Kr8::FrameBuffer::Pos<uint16_t>(x, i), Kr8::FrameBuffer::Color(255, 255, 255));
+    }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,14 @@
 // in the VGA buffer.
 #include <stdint.h>
 
+// Read the current value of the Time-Stamp counter.
+// @return: Current value of TSC on this cpu.
+extern uint64_t readTsc(void);
+
+// Get the frequency of the Time-Stamp counter.
+// @return: Frequency of this cpu's TSC in Hz.
+extern uint64_t getTscFreq(void);
+
 namespace Kr8 {
 // Abstraction for the VGA buffer residing in memory at address 0xB8000.
 class VGABuffer {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,11 +4,15 @@
 
 // Read the current value of the Time-Stamp counter.
 // @return: Current value of TSC on this cpu.
-extern uint64_t readTsc(void);
+extern "C" uint64_t readTsc(void);
 
 // Get the frequency of the Time-Stamp counter.
 // @return: Frequency of this cpu's TSC in Hz.
-extern uint64_t getTscFreq(void);
+extern "C" uint64_t getTscFreq(void);
+
+// Print out a NUL-terminated string to the serial console.
+// @param msg: The NUL-terminated string to print out.
+extern "C" void logSerial(char const * const msg);
 
 namespace Kr8 {
 // Abstraction for the VGA buffer residing in memory at address 0xB8000.
@@ -211,4 +215,5 @@ extern "C" void _start(Kr8::FrameBufferInfo const * const fbInfo) {
         uint16_t const x = fbInfo->width / 2;
         fb.putPixel(Kr8::FrameBuffer::Pos<uint16_t>(x, i), Kr8::FrameBuffer::Color(255, 255, 255));
     }
+    logSerial("Hello world in the serial console from the application\n");
 }


### PR DESCRIPTION
More Bootstrap work:

- Initialization of FPU and AVX-2 extensions before starting the application. The application can now use floating point arithmetic.
- Added serial output for debugging in Qemu.
- Added VESA video mode initialization and framebuffer mapping. The application can now draw on the screen using memory mapped framebuffer. The framebuffer information is passed to the application through the first argument of the _start function.
- Added C++ stubs to draw on the framebuffer.
- Parsing of ACPI tables upon boot. For now we only support ACPI v1, which means it won't work on baremetal just yet, only Qemu. Support for ACPI v2 is not much more work and will be added later.
- Added support for Interrupts handling.
- Added support for Local APIC (for now only timer and End-Of-Interrupt signaling).
- Added support for I/O APIC and legacy IRQ redirection.
- Added support for Programmable Interval Timer (PIT). The PIT is mainly used to calibrate other hardware timers with undefined frequency (LAPIC timer and TSC).
- Added different methods for TSC calibration, some of which giving exact TSC frequency  (this is usually only possible on baremetal, for Qemu we fall back to calibration with PIT).
- Added support for syscalls through software interrupts. The only syscall available for now is GET_TSC_FREQ returning the TSC's frequency. A wrapper for this syscall was added in C++.
- More testing of the bootstrap code (mainly long mode code).